### PR TITLE
feat(odin): add the ODIN procedure runner (mock/bench backends + web UI)

### DIFF
--- a/config.py
+++ b/config.py
@@ -103,6 +103,29 @@ def available_products() -> list[str]:
     )
 
 
+def resolve_odin_bundle(root: Path | None,
+                        override: str | None = None) -> Path | None:
+    """Resolve the ODIN graph bundle's ``networks/`` dir.
+
+    The firmware ships ``opt/odin/odin_bundle.zip``; once unzipped, the graphs
+    live under ``opt/odin/.../networks`` (the exact wrapper dir depends on how it
+    was extracted). ``TM3_ODIN_BUNDLE`` overrides the whole path; otherwise we try
+    the known layouts under ``<root>/opt/odin``. Returns None if unresolved.
+    """
+    if override:
+        return Path(override).expanduser()
+    if root is None:
+        return None
+    odin = root / "opt/odin"
+    for cand in ("odin_bundle_extracted/odin_bundle/networks",
+                 "odin_bundle/odin_bundle/networks",
+                 "odin_bundle/networks"):
+        p = odin / cand
+        if p.is_dir():
+            return p
+    return None
+
+
 class FwPaths:
     """Resolved firmware data paths for a specific product.
 
@@ -126,13 +149,63 @@ class FwPaths:
 # Module-level paths for the default product. All derive from TM3_ROOT
 # (and TM3_PRODUCT) — there are no per-path env overrides; use FwPaths to
 # resolve a non-default product.
+ROOT:          Path | None = _ROOT  # squashfs-root of the firmware extraction
 NODES_JSON:    Path | None = _DATA_DIR / "nodes.json" if _DATA_DIR else None
 ETH_COMPACT:   Path | None = _resolve_compact("ETH")
 ODJ_DIR:       Path | None = _DATA_DIR / "odj" if _DATA_DIR else None
 ARTIFACTS_DIR: Path | None = _ROOT / "deploy/seed_artifacts_v2" if _ROOT else None
+# ODIN graph bundle (networks/ dir) — derived from TM3_ROOT, or TM3_ODIN_BUNDLE.
+ODIN_BUNDLE:   Path | None = resolve_odin_bundle(_ROOT, os.environ.get("TM3_ODIN_BUNDLE"))
 
 # All compact DBs for the selected product, keyed by bus token (ETH, VCRIGHTV, ...).
 COMPACT_DBS: dict[str, Path] = compact_dbs()
+
+# ---------------------------------------------------------------------------
+# CAN channels — the three Model 3 buses
+# ---------------------------------------------------------------------------
+# Downstream tools (odin_runner, ...) pick the right channel per bus.
+# TM3_VEHICLE_CHANNEL is the vehicle bus; it falls back to the generic
+# TM3_CHANNEL so existing single-bus .env files keep working. Party/charge are
+# None unless configured (a simple bench has only the vehicle bus, and callers
+# fall back to it).
+VEHICLE_CHANNEL: str | None = (
+    os.environ.get("TM3_VEHICLE_CHANNEL") or os.environ.get("TM3_CHANNEL")
+)
+PARTY_CHANNEL:   str | None = os.environ.get("TM3_PARTY_CHANNEL")
+CHARGE_CHANNEL:  str | None = os.environ.get("TM3_CHARGE_CHANNEL")
+
+CAN_CHANNELS: dict[str, str | None] = {
+    "vehicle": VEHICLE_CHANNEL,
+    "party":   PARTY_CHANNEL,
+    "charge":  CHARGE_CHANNEL,
+}
+
+# Target firmware revision for message layouts. None => newest authored set.
+FW_VERSION: str | None = os.environ.get("TM3_FW")
+
+# ODIN/Tesla bus tokens -> our bus keys.
+_BUS_ALIASES = {
+    "veh": "vehicle", "vehicle": "vehicle", "eth": "vehicle",
+    "party": "party", "pt": "party",
+    "ch": "charge", "chg": "charge", "charge": "charge",
+}
+
+
+def canonical_bus(bus: str | None = None) -> str:
+    """Normalize an ODIN/Tesla bus token to a canonical key: 'vehicle', 'party', or
+    'charge'. ETH (the vehicle backbone) and any unknown/empty token map to 'vehicle'
+    -- i.e. assume the vehicle bus unless another is explicitly named.
+    """
+    return _BUS_ALIASES.get(str(bus or "").strip().lower(), "vehicle")
+
+
+def can_channel(bus: str | None = None) -> str | None:
+    """Resolve an ODIN/Tesla bus token (VEH / PARTY / CH / ETH …) to a CAN
+    channel. Unknown or empty bus -> the vehicle channel; a bus with no channel
+    configured returns None (the caller falls back to the vehicle channel).
+    """
+    return CAN_CHANNELS.get(canonical_bus(bus))
+
 
 # ---------------------------------------------------------------------------
 # CAN / argparse defaults

--- a/dump_odin.py
+++ b/dump_odin.py
@@ -19,7 +19,7 @@ The .bin decryption key (TM3_BIN_KEY in .env) is the base64 constant ``C`` in
 Decode of ``binary_metadata_reader`` there: salt = first 16 bytes of the file,
 key = PBKDF2-HMAC-SHA256(base64decode(C), salt, 123456 iters, 32 bytes) then
 Fernet-decrypt + ``pickle.loads``. To validate a build / refresh the key:
-    grep -rn "^C = " <out>/src/.../odin/platforms/binary_metadata_utils.py
+    grep -rn "^C = " <out>/src/.../odin_extracted/platforms/binary_metadata_utils.py
 and compare against TM3_BIN_KEY in .env (see .env.example).
 
 Usage:
@@ -29,6 +29,7 @@ Example:
   python dump_odin.py /home/outlandnish/dev/tesla-fw/2026.8.3.ice \\
       --out ~/dev/odin-dumps/2026.8.3
 """
+
 from __future__ import annotations
 
 import argparse
@@ -42,14 +43,45 @@ _DEFAULT_TOOLS = Path("~/dev/tools").expanduser()
 # CPython bytecode magic (first 2 bytes of a .pyc) -> python version label.
 # Enough to pick a decompiler; extend as new builds appear.
 _MAGIC = {
-    3360: "3.6", 3361: "3.6", 3377: "3.6", 3379: "3.6",
-    3390: "3.7", 3391: "3.7", 3392: "3.7", 3393: "3.7", 3394: "3.7",
-    3400: "3.8", 3401: "3.8", 3410: "3.8", 3411: "3.8", 3412: "3.8", 3413: "3.8",
-    3420: "3.9", 3421: "3.9", 3422: "3.9", 3423: "3.9", 3424: "3.9", 3425: "3.9",
-    3430: "3.10", 3431: "3.10", 3432: "3.10", 3433: "3.10", 3434: "3.10", 3435: "3.10",
-    3436: "3.10", 3437: "3.10", 3438: "3.10", 3439: "3.10",
-    3450: "3.11", 3451: "3.11", 3452: "3.11", 3453: "3.11", 3454: "3.11", 3455: "3.11",
-    3531: "3.12", 3571: "3.13",
+    3360: "3.6",
+    3361: "3.6",
+    3377: "3.6",
+    3379: "3.6",
+    3390: "3.7",
+    3391: "3.7",
+    3392: "3.7",
+    3393: "3.7",
+    3394: "3.7",
+    3400: "3.8",
+    3401: "3.8",
+    3410: "3.8",
+    3411: "3.8",
+    3412: "3.8",
+    3413: "3.8",
+    3420: "3.9",
+    3421: "3.9",
+    3422: "3.9",
+    3423: "3.9",
+    3424: "3.9",
+    3425: "3.9",
+    3430: "3.10",
+    3431: "3.10",
+    3432: "3.10",
+    3433: "3.10",
+    3434: "3.10",
+    3435: "3.10",
+    3436: "3.10",
+    3437: "3.10",
+    3438: "3.10",
+    3439: "3.10",
+    3450: "3.11",
+    3451: "3.11",
+    3452: "3.11",
+    3453: "3.11",
+    3454: "3.11",
+    3455: "3.11",
+    3531: "3.12",
+    3571: "3.13",
 }
 
 
@@ -86,16 +118,17 @@ def _resolve_extractor(pyver: str | None) -> tuple[str, str]:
 
     uv = Path("~/.local/bin/uv").expanduser()
     if uv.exists():
-        find = subprocess.run([str(uv), "python", "find", pyver],
-                              capture_output=True, text=True)
+        find = subprocess.run([str(uv), "python", "find", pyver], capture_output=True, text=True)
         if find.returncode == 0 and find.stdout.strip():
             return ("local", find.stdout.strip())
 
     if _has_docker():
         return ("docker", f"python:{pyver}-slim")
 
-    print(f"  ! no Python {pyver} via host/uv and no Docker; using {cur} — "
-          f"PYZ may not unmarshal. Try: uv python install {pyver}")
+    print(
+        f"  ! no Python {pyver} via host/uv and no Docker; using {cur} — "
+        f"PYZ may not unmarshal. Try: uv python install {pyver}"
+    )
     return ("local", sys.executable)
 
 
@@ -128,12 +161,10 @@ def _pyver_from_libpython(odin_dir: Path) -> str | None:
     return None
 
 
-def extract(odin_bin: Path, out: Path, tools: Path,
-            extractor: tuple[str, str]) -> Path:
+def extract(odin_bin: Path, out: Path, tools: Path, extractor: tuple[str, str]) -> Path:
     pyinstx = tools / "pyinstxtractor.py"
     if not pyinstx.exists():
-        sys.exit(f"pyinstxtractor.py not found at {pyinstx} "
-                 "(fetch it into --tools first)")
+        sys.exit(f"pyinstxtractor.py not found at {pyinstx} (fetch it into --tools first)")
     out.mkdir(parents=True, exist_ok=True)
     extracted = out / "extracted"
     extracted.mkdir(exist_ok=True)
@@ -144,13 +175,22 @@ def extract(odin_bin: Path, out: Path, tools: Path,
         # pyinstxtractor inside the container with the output dir as cwd so the
         # <name>_extracted tree lands on the host. -u for live output.
         cmd = [
-            "docker", "run", "--rm",
-            "-v", f"{odin_bin}:/in/odin:ro",
-            "-v", f"{pyinstx}:/in/pyinstxtractor.py:ro",
-            "-v", f"{extracted}:/out",
-            "-w", "/out",
+            "docker",
+            "run",
+            "--rm",
+            "-v",
+            f"{odin_bin}:/in/odin:ro",
+            "-v",
+            f"{pyinstx}:/in/pyinstxtractor.py:ro",
+            "-v",
+            f"{extracted}:/out",
+            "-w",
+            "/out",
             ref,
-            "python", "-u", "/in/pyinstxtractor.py", "/in/odin",
+            "python",
+            "-u",
+            "/in/pyinstxtractor.py",
+            "/in/odin",
         ]
     else:
         # pyinstxtractor writes <name>_extracted in cwd; run it inside
@@ -180,10 +220,11 @@ def decompile(extracted: Path, out: Path, pyver: str | None, tools: Path) -> Non
             print("  pycdc not built; falling back to uncompyle6 (py<=3.8 only)")
         else:
             sys.exit(
-                f"pycdc not found at {tools/'pycdc'/'pycdc'} and python {pyver} "
+                f"pycdc not found at {tools / 'pycdc' / 'pycdc'} and python {pyver} "
                 "is out of uncompyle6 range. Build pycdc:\n"
                 "  sudo apt-get install -y cmake\n"
-                "  cd ~/dev/tools/pycdc && cmake . && make -j$(nproc)")
+                "  cd ~/dev/tools/pycdc && cmake . && make -j$(nproc)"
+            )
 
     pycs = sorted(extracted.rglob("*.pyc"))
     print(f"  decompiling {len(pycs)} .pyc -> {src}")
@@ -194,12 +235,10 @@ def decompile(extracted: Path, out: Path, pyver: str | None, tools: Path) -> Non
         dst.parent.mkdir(parents=True, exist_ok=True)
         try:
             if use_uncompyle:
-                res = subprocess.run(["uncompyle6", str(pyc)],
-                                     capture_output=True, text=True)
+                res = subprocess.run(["uncompyle6", str(pyc)], capture_output=True, text=True)
                 out_text = res.stdout
             else:
-                res = subprocess.run([str(pycdc), str(pyc)],
-                                     capture_output=True, text=True)
+                res = subprocess.run([str(pycdc), str(pyc)], capture_output=True, text=True)
                 out_text = res.stdout
             if out_text.strip():
                 dst.write_text(out_text)
@@ -214,15 +253,23 @@ def decompile(extracted: Path, out: Path, pyver: str | None, tools: Path) -> Non
 
 def main() -> None:
     ap = argparse.ArgumentParser(
-        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
-    ap.add_argument("firmware_root", type=Path,
-                    help="Squashfs root of a firmware extraction")
-    ap.add_argument("--out", type=Path, default=None,
-                    help="Output dir (default: ~/dev/odin-dumps/<root name>)")
-    ap.add_argument("--tools", type=Path, default=_DEFAULT_TOOLS,
-                    help="Dir holding pyinstxtractor.py and pycdc/ (default: ~/dev/tools)")
-    ap.add_argument("--no-decompile", action="store_true",
-                    help="Only extract the PyInstaller archive; skip decompile")
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    ap.add_argument("firmware_root", type=Path, help="Squashfs root of a firmware extraction")
+    ap.add_argument(
+        "--out", type=Path, default=None, help="Output dir (default: ~/dev/odin-dumps/<root name>)"
+    )
+    ap.add_argument(
+        "--tools",
+        type=Path,
+        default=_DEFAULT_TOOLS,
+        help="Dir holding pyinstxtractor.py and pycdc/ (default: ~/dev/tools)",
+    )
+    ap.add_argument(
+        "--no-decompile",
+        action="store_true",
+        help="Only extract the PyInstaller archive; skip decompile",
+    )
     args = ap.parse_args()
 
     root = args.firmware_root.expanduser()
@@ -230,8 +277,7 @@ def main() -> None:
     if not odin_bin.exists():
         sys.exit(f"odin binary not found at {odin_bin}")
 
-    out = args.out.expanduser() if args.out else \
-        Path("~/dev/odin-dumps").expanduser() / root.name
+    out = args.out.expanduser() if args.out else Path("~/dev/odin-dumps").expanduser() / root.name
     tools = args.tools.expanduser()
 
     # Detect the frozen Python version up front (from libpython) so extraction
@@ -239,8 +285,7 @@ def main() -> None:
     pyver = _pyver_from_libpython(odin_bin.parent)
     extractor = _resolve_extractor(pyver)
     print(f"[1/3] extracting {odin_bin}")
-    print(f"  target python: {pyver or 'unknown'}  "
-          f"extractor: {extractor[0]}:{extractor[1]}")
+    print(f"  target python: {pyver or 'unknown'}  extractor: {extractor[0]}:{extractor[1]}")
     extracted = extract(odin_bin, out, tools, extractor)
 
     print("[2/3] confirming bundled Python version (from .pyc magic)")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 cryptography>=41.0.0
 ruff>=0.4.0
 python-can>=4.0.0
-py-uds>=4.0.0
+py-uds==4.0.0
 intelhex>=2.3.0
 pytest>=9.0.0
 aiohttp>=3.9.0

--- a/scripts/odin_coverage.py
+++ b/scripts/odin_coverage.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+"""odin_coverage.py -- how much of the ODIN test library odin_runner can execute.
+
+Introspects odin_runner.Engine for its implemented node handlers, then does a
+transitive pass over every entry procedure in the bundle (expanding referenced
+subnetworks), and reports:
+  * procedures runnable NOW (all node types handled)
+  * the ranked worklist of missing node types (each -> #procedures it blocks),
+    split into hardware-interop vs pure-logic handlers
+  * a greedy cumulative projection: add the top-K handlers -> N procedures unlock
+
+Usage:
+  python scripts/odin_coverage.py --bundle <…/networks>
+  python scripts/odin_coverage.py --bundle <…/networks> --entries Model3/tasks --top 20
+"""
+from __future__ import annotations
+
+import argparse
+import collections
+from pathlib import Path
+
+import odin_runner
+
+# structural types handled outside the _ctrl_/_data_ dispatch, or non-executable
+# (networks.Output is materialized by Engine._collect_outputs, not a _ctrl_/_data_ method)
+_STRUCTURAL = {"networks.Enter", "comments.TaskInfo", "networks.Output"}
+_SUBNET_TYPES = {
+    "networks.RunReferencedSubnetwork",
+    "networks.ReferencedSubnetwork",
+    "networks.DynamicallyReferencedSubnetwork",
+    "scripts.RunScriptTest",
+}
+# networks.Subnetwork is an INLINE subgraph: its inner nodes live under non-reserved
+# keys of the node dict (not as a separate file). These keys are structural, not nodes.
+_INLINE_SUBNET_TYPE = "networks.Subnetwork"
+_RESERVED_SUBNET_KEYS = frozenset(
+    {"type", "position", "slots", "signals", "inputs", "outputs", "comment"})
+# module prefixes that require a Backend shim (vs pure compute)
+_INTEROP_MODS = {"uds", "odx", "cid", "can", "vehiclecontrols", "lin", "isotp",
+                 "hardware", "flash", "cidupdater", "apupdater", "hermes", "http",
+                 "cert", "proto", "odin"}
+
+
+def handled_types() -> set[str]:
+    """Node types odin_runner.Engine can currently execute."""
+    out = set(_STRUCTURAL)
+    for attr in dir(odin_runner.Engine):
+        for pre in ("_ctrl_", "_data_"):
+            if attr.startswith(pre):
+                mod, _, nm = attr[len(pre):].partition("_")
+                if nm:
+                    out.add(f"{mod}.{nm}")
+    return out
+
+
+def _basename(node: dict) -> str | None:
+    """Static basename of a subnet-call node, however it names its target:
+    `basename` (ReferencedSubnetwork), `script_name` (RunScriptTest, a bare string),
+    or `name` (DynamicallyReferencedSubnetwork). A connection => dynamic (None)."""
+    for key in ("basename", "script_name", "name"):
+        b = node.get(key)
+        if isinstance(b, str):
+            return b
+        if isinstance(b, dict):
+            if "value" in b:
+                return b["value"]  # a literal; a bare connection => dynamic
+            return None
+    return None
+
+
+def collect(bundle: Path, relbase: str, visited: set, types: collections.Counter,
+            missing_files: set, dynamic: list, *, visit=None) -> None:
+    """Union node types of a graph and everything it (statically) references.
+
+    `visit`, if given, is called `visit(name, node, relbase)` for every node
+    reached by the transitive walk (including INLINE-subnetwork inner nodes), so a
+    caller can gather per-node facts (e.g. CAN reads) over the same descent the
+    coverage counter uses -- no parallel walker needed.
+    """
+    if relbase in visited:
+        return
+    visited.add(relbase)
+    path = bundle / (relbase + ".py")
+    if not path.exists():
+        missing_files.add(relbase)
+        return
+    ns: dict = {}
+    try:
+        exec(compile(path.read_text(encoding="utf-8"), str(path), "exec"), ns)  # noqa: S102
+    except Exception as e:  # noqa: BLE001
+        dynamic.append((relbase, f"parse-error: {e}"))
+        return
+    net = ns.get("network", {})
+    if not isinstance(net, dict):
+        dynamic.append((relbase, f"network-not-dict: {type(net).__name__}"))
+        return
+    _walk_nodes(net, bundle, relbase, visited, types, missing_files, dynamic, visit=visit)
+
+
+def _walk_nodes(nodes: dict, bundle: Path, relbase: str, visited: set,
+                types: collections.Counter, missing_files: set, dynamic: list,
+                *, visit=None) -> None:
+    """Count node types, recursing into referenced files (subnet basenames) and into
+    INLINE networks.Subnetwork inner nodes (which live under the node's own keys)."""
+    for name, node in nodes.items():
+        if not isinstance(node, dict) or "type" not in node:
+            continue
+        t = node["type"]
+        types[t] += 1
+        if visit is not None:
+            visit(name, node, relbase)
+        if t in _SUBNET_TYPES:
+            base = _basename(node)
+            if base is None:
+                dynamic.append((relbase, name))
+            else:
+                collect(bundle, base, visited, types, missing_files, dynamic, visit=visit)
+        elif t == _INLINE_SUBNET_TYPE:
+            inner = {k: v for k, v in node.items()
+                     if k not in _RESERVED_SUBNET_KEYS
+                     and isinstance(v, dict) and "type" in v}
+            _walk_nodes(inner, bundle, relbase, visited, types,
+                        missing_files, dynamic, visit=visit)
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--bundle", type=Path, default=None,
+                   help="…/networks dir (default: config.ODIN_BUNDLE from .env)")
+    p.add_argument("--entries", default="Model3/tasks",
+                   help="entry-procedure dir relative to bundle (default Model3/tasks)")
+    p.add_argument("--top", type=int, default=25, help="worklist length")
+    args = p.parse_args()
+
+    import config as _cfg  # odin_runner import already put the repo root on sys.path
+    bundle = args.bundle or _cfg.ODIN_BUNDLE
+    if bundle is None:
+        p.error("no bundle: pass --bundle or set TM3_ROOT (or TM3_ODIN_BUNDLE) in .env")
+
+    handled = handled_types()
+    entry_dir = bundle / args.entries
+    procs = sorted(f for f in entry_dir.glob("*.py"))
+
+    runnable, blocked = [], {}          # blocked: proc -> set(missing types)
+    blocks = collections.Counter()      # missing type -> #procs it blocks
+    proc_missing: dict[str, set] = {}
+    has_dynamic = []
+
+    for f in procs:
+        rel = f"{args.entries}/{f.stem}"
+        types: collections.Counter = collections.Counter()
+        missing_files: set = set()
+        dynamic: list = []
+        collect(bundle, rel, set(), types, missing_files, dynamic)
+        missing = {t for t in types if t not in handled}
+        proc_missing[f.stem] = missing
+        if dynamic:
+            has_dynamic.append(f.stem)
+        if not missing:
+            runnable.append(f.stem)
+        else:
+            blocked[f.stem] = missing
+            for t in missing:
+                blocks[t] += 1
+
+    print(f"bundle entries ({args.entries}): {len(procs)}")
+    print(f"handler-implemented node types: {len(handled)}")
+    print(f"RUNNABLE NOW (all node types handled): {len(runnable)}  "
+          f"({100*len(runnable)//max(len(procs),1)}%)")
+    for name in [x for x in runnable if "_DI" in x or "DIS" in x][:20]:
+        print(f"    {name}")
+    if len(runnable) > 20:
+        print(f"    … and {len(runnable)-20} more")
+
+    print(f"\nWORKLIST -- missing node types ranked by #procedures they block "
+          f"(top {args.top}):")
+    print(f"  {'#procs':>6}  {'kind':<8}  type")
+    for t, n in blocks.most_common(args.top):
+        kind = "interop" if t.split(".")[0] in _INTEROP_MODS else "logic"
+        print(f"  {n:>6}  {kind:<8}  {t}")
+
+    # greedy cumulative projection
+    print("\nGREEDY UNLOCK -- add handlers in this order, procedures that become runnable:")
+    remaining = dict(blocked)
+    added: list[str] = []
+    cum = len(runnable)
+    for _ in range(args.top):
+        # which single missing type, if handled, frees the most procedures?
+        freed = collections.Counter()
+        for miss in remaining.values():
+            if len(miss) == 1:
+                freed[next(iter(miss))] += 1
+        if not freed:
+            # nothing unlocks a whole proc alone; pick the most-blocking type to chip away
+            nxt = collections.Counter(
+                t for miss in remaining.values() for t in miss).most_common(1)
+            if not nxt:
+                break
+            t = nxt[0][0]
+            for miss in remaining.values():
+                miss.discard(t)
+            added.append(t)
+            print(f"  + {t:<40} (partial; 0 fully unlocked)")
+            continue
+        t, k = freed.most_common(1)[0]
+        cum += k
+        added.append(t)
+        for proc in [pr for pr, miss in remaining.items() if miss == {t}]:
+            del remaining[proc]
+        for miss in remaining.values():
+            miss.discard(t)
+        print(f"  + {t:<40} -> +{k} procs (cumulative {cum}/{len(procs)})")
+
+    if has_dynamic:
+        print(f"\nnote: {len(has_dynamic)} procedures use dynamic/unresolved subnetworks "
+              f"(coverage is a lower bound for those)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/odin_runner.py
+++ b/scripts/odin_runner.py
@@ -1,0 +1,2333 @@
+#!/usr/bin/env python3
+"""odin_runner.py -- minimal interpreter for ODIN node-graph procedures (Path B PoC).
+
+Runs the REAL ODIN diagnostic graphs from the firmware bundle
+(.../networks/Model3/{tasks,lib}/*.py) directly, instead of Tesla's frozen
+odin-engine + web UI. Node-type inventory across the bundle is 181 types, but
+only 5 modules touch hardware (uds / odx / can / cid / vehiclecontrols); the
+other ~90% (networks / control / logic / dicts / reporting / ...) is pure
+compute that runs unchanged. See docs/private/odin-resolver-cal-and-inverter-swap.md.
+
+Execution model (as read out of the graphs):
+  * CONTROL flow is push: a node's control-OUTPUT port (run/done/passed/if_true/
+    save/capture/try_body/...) holds {'connection': 'target.inputport'}; firing it
+    runs the target. networks.Enter.start is the entry; networks.Exit raises out
+    of the run with an exit_code.
+  * DATA flow is pull: an input field is {'connection': 'node.outputport'} (lazy)
+    or {'value': X} (literal). Pulling a data port evaluates that node's data
+    handler. 'connection' wins over a cached 'value'.
+  * control.Split runs two branches concurrently (here: a thread for the infinite
+    tester-present loop + the main sequence inline); Exit cancels the thread.
+
+Hardware interop is behind a Backend seam:
+  * MockBackend  -- scripts the choreography (dyno mode, gear D->N, axle speed,
+                    RESOLVER_LEARNING result) so the graph runs with NO hardware.
+                    This is what validates the interpreter.
+  * BenchBackend -- (skeleton) uds/odx -> uds_local.UdsSession per ECU node;
+                    can -> live-bus decode; cid -> a bench data provider. The
+                    seams are marked; complete them on the bench.
+
+Tesla's ODIN graph files are NOT vendored into this (public) repo. The bundle
+path (and CAN channel/interface) are resolved from .env via config.py -- set
+TM3_ROOT (the firmware extraction) and the bundle + TM3_VEHICLE_CHANNEL/TM3_INTERFACE are
+derived automatically; --bundle / --channel override them.
+
+Usage:
+  python scripts/odin_runner.py --scenario success -v      # bundle from .env
+  python scripts/odin_runner.py --bundle <…/networks> --scenario not-dyno
+  python scripts/odin_runner.py --procedure Model3/tasks/PROC_DI_X_RESOLVER-LEARN
+"""
+from __future__ import annotations
+
+import argparse
+import base64
+import contextlib
+import datetime
+import hashlib
+import json
+import os
+import re
+import string
+import sys
+import threading
+import time
+import uuid
+from dataclasses import dataclass, field
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+DEFAULT_PROC = "Model3/tasks/PROC_DI_X_RESOLVER-LEARN"
+
+
+# =====================================================================================
+# graph loading
+# =====================================================================================
+def load_graph(bundle: Path, relbase: str) -> dict:
+    """Load a bundle graph by its basename (e.g. 'Model3/lib/DI_RESOLVER_LEARNING')."""
+    path = bundle / (relbase + ".py")
+    ns: dict = {}
+    exec(compile(path.read_text(encoding="utf-8"), str(path), "exec"), ns)  # noqa: S102
+    if "network" not in ns:
+        raise ValueError(f"{path} has no top-level `network` dict")
+    return ns["network"]
+
+
+class GraphExit(Exception):
+    """networks.Exit -- unwinds the current graph run with an exit code."""
+
+    def __init__(self, code):
+        self.code = code
+        super().__init__(f"exit {code}")
+
+
+class ProcedureError(Exception):
+    """Unsupported node type or malformed graph."""
+
+
+class _BreakLoop(Exception):
+    """control.Break -- unwinds to the nearest enclosing loop, which stops
+    iterating and continues via its normal completion port."""
+
+
+@dataclass
+class Frame:
+    graph: dict
+    inputs: dict
+    depth: int = 0
+    vars: dict = field(default_factory=dict)
+    metrics: list = field(default_factory=list)
+    scratch: dict = field(default_factory=dict)
+    outputs: dict = field(default_factory=dict)  # this graph's named outputs (SetOutput / networks.Output)
+    threads: list = field(default_factory=list)
+    cancel: threading.Event = field(default_factory=threading.Event)
+
+
+@dataclass
+class RunResult:
+    exit_code: object
+    metrics: list
+    outputs: dict
+
+
+# =====================================================================================
+# CID emulation (cid.* nodes): a read-your-writes data-value store + a read-only
+# view of a firmware-dump rootfs. See docs/private/odin-runner-plan.md (Step 5).
+# =====================================================================================
+# Sensible bench defaults for CID data-values graphs read back after (or without)
+# a SetDataValue. Values are strings, matching the CID data-value wire type.
+_CID_DEFAULTS = {
+    "GUI_factoryMode": "false", "GUI_developerMode": "false",
+    "GUI_diagnosticMode": "false", "GUI_tdsMode": "false",
+    "GUI_serviceMode": "false", "GUI_isDelivered": "true",
+    "VAPI_isLocked": "false", "VAPI_driverPresent": "true",
+    "VAPI_countryCode": "US", "VAPI_europeVehicle": "false",
+    "VAPI_odometer": "0", "VAPI_doorState": "closed",
+}
+
+
+class CidStore:
+    """Read-your-writes CID data-value store + in-memory SaveData/LoadData blobs.
+
+    `derive(name)` (optional) supplies live/derived values (e.g. VAPI_shiftState
+    from the bus) and wins over stored values when it returns non-None.
+    """
+
+    def __init__(self, seed: dict | None = None, derive=None):
+        self.values = dict(_CID_DEFAULTS)
+        if seed:
+            self.values.update(seed)
+        self.blobs: dict = {}
+        self._derive = derive
+
+    def get(self, name):
+        if self._derive is not None:
+            v = self._derive(name)
+            if v is not None:
+                return v
+        return self.values.get(name)
+
+    def set(self, name, value):
+        self.values[name] = value
+
+    def list(self, names):
+        return {n: self.get(n) for n in (names or [])}
+
+    def save(self, filename, data):
+        self.blobs[filename] = data
+
+    def load(self, filename):
+        return self.blobs.get(filename)
+
+
+class CidFilesystem:
+    """Read-only view of a firmware-dump rootfs for CID filesystem ops.
+
+    Maps a CID absolute path onto <root>/<path>, JAILED so it can never escape the
+    root and never writes. Serves real data for static firmware content; paths
+    absent from the dump (runtime state: logs, /var/etc, device nodes) read as
+    empty / not-found -- which is what a freshly-flashed unit actually has.
+    """
+
+    def __init__(self, root: Path | str | None):
+        self.root = Path(root).expanduser().resolve() if root else None
+
+    def _resolve(self, cid_path) -> Path | None:
+        if self.root is None:
+            return None
+        full = (self.root / str(cid_path or "").lstrip("/")).resolve()
+        if full != self.root and self.root not in full.parents:
+            return None  # path-jail: escaped the firmware root
+        return full
+
+    def hash_file(self, path, algorithm="sha256"):
+        full = self._resolve(path)
+        if full is None or not full.is_file():
+            return None
+        algo = str(algorithm or "sha256").lower().replace("-", "")
+        try:
+            h = hashlib.new(algo)
+        except (ValueError, TypeError):
+            return None
+        h.update(full.read_bytes())
+        return h.hexdigest()
+
+    def list_dir(self, directory, show_hidden=False, details=False):
+        full = self._resolve(directory)
+        if full is None or not full.is_dir():
+            return []
+        entries = sorted(p for p in full.iterdir()
+                         if show_hidden or not p.name.startswith("."))
+        if not details:
+            return [p.name for p in entries]
+        return [{"name": p.name, "is_dir": p.is_dir(),
+                 "size": p.stat().st_size if p.is_file() else 0} for p in entries]
+
+    def grep(self, pattern, file_location):
+        full = self._resolve(file_location)
+        if full is None or not full.is_file():
+            return []
+        with contextlib.suppress(OSError, re.error):
+            return [ln for ln in full.read_text(errors="replace").splitlines()
+                    if re.search(str(pattern), ln)]
+        return []
+
+    def read_text(self, path):
+        full = self._resolve(path)
+        if full is None or not full.is_file():
+            return None
+        with contextlib.suppress(OSError):
+            return full.read_text(errors="replace")
+        return None
+
+    def read_bytes(self, path):
+        full = self._resolve(path)
+        if full is None or not full.is_file():
+            return None
+        with contextlib.suppress(OSError):
+            return full.read_bytes()
+        return None
+
+
+# =====================================================================================
+# backends (the hardware-interop seam)
+# =====================================================================================
+class Backend:
+    """Interface the interop node handlers call. One impl per environment."""
+
+    def uds(self, node_name: str):
+        raise NotImplementedError
+
+    def odx(self, node_name: str):
+        raise NotImplementedError
+
+    def cid_get(self, name: str):
+        return None
+
+    def cid_set(self, name: str, value) -> None:
+        pass
+
+    def can_read(self, signal: str, bus: str | None = None):
+        return None  # override to decode a live bus; None => signal unseen
+
+    def can_active_alerts(self, bus=None, prefix=None, audience=None):
+        # can.ActiveAlerts: the alerts currently asserted on a bus. Decoding the
+        # alert matrix off a live bus needs the alert DB; a bench returns none.
+        return []
+
+    def isotp_send(self, to_controller, from_controller, data, bus=None) -> bool:
+        # isotp.Send: transmit a raw ISO-TP message with explicit tx/rx CAN IDs
+        # (not a UDS service). No transport off a bench -> report success.
+        return True
+
+    # Power / application-state orchestration (vehiclecontrols.*). Default no-op:
+    # a bench assumes the requested state already holds. Override to actually drive
+    # it (e.g. vehicle_sim's LV/BMS via its HTTP control server).
+    def ensure_power_state(self, state) -> None:
+        pass
+
+    def ensure_application_state(self, node_name: str, state) -> None:
+        pass
+
+    def store_outputs(self, outputs) -> None:
+        # Persist a procedure's outputs to the interop data store, keyed by board id.
+        # Default: no-op (offline / mock). BenchBackend overrides.
+        pass
+
+    # -- cid.* emulation (default: empty/stub; MockBackend + BenchBackend override) --
+    def cid_list_values(self, names):
+        return {n: self.cid_get(n) for n in (names or [])}
+
+    def cid_save(self, filename, data) -> None:
+        pass
+
+    def cid_load(self, filename):
+        return None
+
+    def cid_hash_file(self, path, algorithm="sha256"):
+        return None
+
+    def cid_list_dir(self, directory, **opts):
+        return []
+
+    def cid_grep(self, pattern, file_location, args=None):
+        return []
+
+    def cid_disk_free(self, mountpoint):
+        return 0
+
+    def cid_vin(self, in_hex=False):
+        return None
+
+    def cid_vitals(self):
+        return {}
+
+    def cid_execute(self, **kwargs):
+        # Stubbed shell execution (ExecuteApplication / CidCommand / ExecuteScript):
+        # the firmware dump's binaries can't be run, so return canned success.
+        return {"stdout": "", "stderr": "", "exit_status": 0}
+
+    def cid_read_file(self, path, mode="r"):
+        # proto.ReadFile: served from the firmware dump on a bench (None otherwise).
+        return None
+
+
+class MockBackend(Backend):
+    """Scripts the resolver-learn choreography so the graph runs with no hardware.
+
+    Scenarios: success | not-dyno | speed-fail | learn-fail. The mock advances
+    VAPI_shiftState D->N when the ESP dyno routine (0xf00a) is started, mirroring
+    the operator shifting during the real procedure.
+    """
+
+    def __init__(self, scenario: str = "success"):
+        self.scenario = scenario
+        self.gear = "D"
+        self.traction = "Normal" if scenario == "not-dyno" else "Dyno"
+        self.axle_speed = 100 if scenario == "speed-fail" else 600
+        self.learn = "SPEED_RANGE" if scenario == "learn-fail" else "LEARN_SUCCESS"
+        # read-your-writes store; gear/traction stay live via the derive callback.
+        self._cid = CidStore(derive=self._derive_cid)
+
+    def _derive_cid(self, name):
+        if name == "GUI_tractionControlModeRequest":
+            return self.traction
+        if name == "VAPI_shiftState":
+            return self.gear
+        return None
+
+    # -- interop --
+    def uds(self, node_name):
+        return _MockUds(self, node_name)
+
+    def odx(self, node_name):
+        return _MockOdx(self, node_name)
+
+    def cid_get(self, name):
+        return self._cid.get(name)
+
+    def cid_set(self, name, value):
+        self._cid.set(name, value)
+
+    def cid_list_values(self, names):
+        return self._cid.list(names)
+
+    def cid_save(self, filename, data):
+        self._cid.save(filename, data)
+
+    def cid_load(self, filename):
+        return self._cid.load(filename)
+
+    def can_read(self, signal, bus=None):
+        if signal and signal.endswith("axleSpeed"):
+            return self.axle_speed
+        return 0
+
+
+class _MockUds:
+    def __init__(self, backend: MockBackend, node: str):
+        self.backend = backend
+        self.node = node
+
+    def tester_present(self):
+        pass
+
+    def diagnostic_session(self, session_type):
+        pass
+
+    def routine_control(self, routine_id, payload=None, routine_type=None):
+        # The ESP 0xf00a routine is the dyno enable; simulate the operator having
+        # shifted into Neutral by the time it starts.
+        if self.node == "ESP":
+            self.backend.gear = "N"
+        return b""
+
+    def security_access(self, *_a, **_k): pass
+    def read_data(self, *_a, **_k): return b""
+    def write_data(self, *_a, **_k): pass
+    def io_control(self, *_a, **_k): return b""
+    def ecu_reset(self, *_a, **_k): pass
+    def clear_dtcs(self, *_a, **_k): pass
+    def read_dtcs(self, *_a, **_k): return {}
+
+
+class _MockOdx:
+    def __init__(self, backend: MockBackend, node: str):
+        self.backend = backend
+        self.node = node
+
+    def start_and_wait(self, routine, status_param, in_progress, timeout, **_):
+        if routine == "RESOLVER_LEARNING":
+            return {"LEARN_RESULT": self.backend.learn, "RUNNING": False, "RMSERROR": 0.5}
+        return {}
+
+    def start_routine(self, *_a, **_k): return b""
+    def stop_routine(self, *_a, **_k): return b""
+    def request_results(self, *_a, **_k): return {}
+    def read_data(self, *_a, **_k): return {}
+    def write_data(self, *_a, **_k): pass
+    def get_value(self, routine, param_name, param_value, parsed): return param_value
+
+
+def _to_int(v, default=0):
+    """Coerce a routine/DID id from ODIN (hex string '0xfd40' or int) to int."""
+    if v is None:
+        return default
+    if isinstance(v, int):
+        return v
+    s = str(v).strip()
+    return int(s, 16) if s.lower().startswith("0x") else int(s, 0)
+
+
+def _trailing_int(s, default=0):
+    """'LEVEL_5' -> 5; falls back to `default` if no trailing digits."""
+    m = re.search(r"(\d+)\s*$", str(s or ""))
+    return int(m.group(1)) if m else default
+
+
+class _CanRxCache:
+    """python-can Listener that decodes every inbound frame into a {signal: value}
+    cache via a can_decoder.CanDatabase. `can_read` reads the latest value."""
+
+    def __init__(self, db):
+        self._db = db
+        self._signals: dict = {}
+        self._lock = threading.Lock()
+
+    def on_message_received(self, msg) -> None:
+        if msg.is_error_frame or msg.is_remote_frame:
+            return
+        decoded = self._db.decode_frame(msg.arbitration_id, bytes(msg.data))
+        if decoded:
+            with self._lock:
+                for s in decoded:
+                    self._signals[s["signal"]] = s["value"]
+
+    def get(self, name):
+        with self._lock:
+            return self._signals.get(name)
+
+    def stop(self) -> None:
+        pass
+
+
+class BenchBackend(Backend):
+    """Real bench: uds/odx map to one uds_local.UdsSession per ECU node (cached,
+    with a TesterPresent keep-alive), driven off the ODJ (NodeConfig) + odj_codec.
+
+    NOTE: on a conversion there is no ESP module -- uds('ESP')/odx('ESP') return
+    no-op stubs so the resolver-learn graph's brake/dyno choreography (routed via
+    ESP) does not block. `can_read` decodes a live-bus RX cache (CanDatabase); the
+    CID data-value store is read-your-writes; the CID filesystem is a read-only view
+    of the firmware dump.
+    """
+
+    def __init__(self, channel: str, interface: str = "socketcan",
+                 cid_values: dict | None = None, firmware_root=None, datastore=None):
+        self.channel = channel
+        self.interface = interface
+        self._nodes: dict = {}   # NODE (upper) -> (NodeConfig, UdsSession)
+        self._can: dict = {}     # channel -> (bus, notifier, _CanRxCache), lazy
+        self._isotp: dict = {}   # (channel, tx, rx) -> (bus, notifier, transport), lazy
+        self._datastore = datastore  # interop DataStore for stored outputs (lazy)
+        self._bootloader: set = set()  # NODES currently held in their bootloader
+        # CID data-value store (read-your-writes) + read-only firmware-dump FS.
+        # firmware_root defaults to TM3_ROOT (config.ROOT); None => FS ops stub empty.
+        self._cid = CidStore(seed=cid_values)
+        if firmware_root is None:
+            import config as _cfg
+            firmware_root = _cfg.ROOT
+        self._fs = CidFilesystem(firmware_root)
+
+    def _node(self, node_name):
+        key = node_name.upper()
+        if key not in self._nodes:
+            import config as _cfg
+            from uds_local.client import UdsSession
+            from uds_local.node_config import load_node_config
+            cfg = load_node_config(node_name, _cfg.NODES_JSON, _cfg.ETH_COMPACT,
+                                   _cfg.ODJ_DIR)
+            sess = UdsSession(cfg, self.channel, interface=self.interface)
+            sess.start_tester_present()
+            self._nodes[key] = (cfg, sess)
+        return self._nodes[key]
+
+    def open_node(self, node_name):
+        """(NodeConfig, UdsSession) for a node -- the seam odin_service's DID helpers
+        (list_dids/read_did/write_did) need. Reuses the cached per-node session."""
+        return self._node(node_name)
+
+    def uds(self, node_name):
+        if node_name.upper() == "ESP":
+            return _StubUds()  # no ESP on a conversion bench
+        _cfg, sess = self._node(node_name)
+        return _UdsAdapter(sess)
+
+    def odx(self, node_name):
+        if node_name.upper() == "ESP":
+            return _StubOdx()
+        cfg, sess = self._node(node_name)
+        return _OdxAdapter(sess, cfg)
+
+    # -- cid data-value store (read-your-writes; wire derive to the live bus later) --
+    def cid_get(self, name):
+        return self._cid.get(name)
+
+    def cid_set(self, name, value):
+        self._cid.set(name, value)
+
+    def cid_list_values(self, names):
+        return self._cid.list(names)
+
+    def cid_save(self, filename, data):
+        self._cid.save(filename, data)
+
+    def cid_load(self, filename):
+        return self._cid.load(filename)
+
+    # -- cid filesystem (real data from the firmware dump, read-only) --
+    def cid_hash_file(self, path, algorithm="sha256"):
+        return self._fs.hash_file(path, algorithm)
+
+    def cid_list_dir(self, directory, **opts):
+        return self._fs.list_dir(directory, show_hidden=opts.get("show_hidden", False),
+                                 details=opts.get("details", False))
+
+    def cid_grep(self, pattern, file_location, args=None):
+        return self._fs.grep(pattern, file_location)
+
+    def cid_disk_free(self, mountpoint):
+        return 8 * 1024 * 1024 * 1024  # placeholder 8 GiB (dump has no live free space)
+
+    def cid_vin(self, in_hex=False):
+        return self._cid.get("VAPI_vin") or "5YJ3E1EA0LF000000"  # placeholder VIN
+
+    def cid_vitals(self):
+        osr = self._fs.read_text("/etc/os-release") or ""
+        return {"os_release": osr, "vin": self.cid_vin()}
+
+    def cid_read_file(self, path, mode="r"):
+        return self._fs.read_bytes(path) if "b" in str(mode) else self._fs.read_text(path)
+
+    # -- live CAN: one RX cache per channel; can_read routes bus -> channel --
+    def _can_cache(self, channel):
+        if channel not in self._can:
+            import can
+
+            import config as _cfg
+            from can_decoder import CanDatabase
+            db = CanDatabase(str(_cfg.ETH_COMPACT)) if _cfg.ETH_COMPACT else CanDatabase()
+            bus = can.Bus(interface=self.interface, channel=channel)
+            notifier = can.Notifier(bus, [])
+            cache = _CanRxCache(db)
+            notifier.add_listener(cache)
+            self._can[channel] = (bus, notifier, cache)
+        return self._can[channel][2]
+
+    def can_read(self, signal, bus=None):
+        # Resolve the ODIN bus_name (ETH/VEH/PARTY/CH) to a configured channel;
+        # unconfigured buses fall back to this backend's channel (vehicle bus).
+        import config as _cfg
+        channel = _cfg.can_channel(bus) or self.channel
+        if channel is None:
+            return None
+        return self._can_cache(channel).get(signal)
+
+    # -- raw ISO-TP send (isotp.Send). Reuses the py-uds transport the UDS stack is
+    # built on, with explicit tx/rx CAN IDs (to_controller/from_controller) instead of
+    # a node's configured pair -- so it needs its own transport (own bus+notifier, one
+    # per (channel, tx, rx)) rather than a per-node UdsSession. --
+    def _isotp_transport(self, channel, tx_id, rx_id):
+        key = (channel, tx_id, rx_id)
+        if key not in self._isotp:
+            import can
+            from uds.can.addressing import NormalCanAddressingInformation
+            from uds.can.transport_interface import PyCanTransportInterface
+            bus = can.Bus(interface=self.interface, channel=channel)
+            notifier = can.Notifier(bus, [])
+            addr = NormalCanAddressingInformation(
+                rx_physical_params={"can_id": rx_id},
+                tx_physical_params={"can_id": tx_id},
+                rx_functional_params={"can_id": 0x7E8},
+                tx_functional_params={"can_id": 0x7DF},
+            )
+            tp = PyCanTransportInterface(
+                network_manager=bus, addressing_information=addr, notifier=notifier)
+            self._isotp[key] = (bus, notifier, tp)
+        return self._isotp[key][2]
+
+    def isotp_send(self, to_controller, from_controller, data, bus=None):
+        from uds.addressing import AddressingType
+        from uds.message import UdsMessage
+
+        import config as _cfg
+        channel = _cfg.can_channel(bus) or self.channel
+        if channel is None:
+            return False
+        if isinstance(data, str):
+            data = bytes.fromhex(data)
+        elif data is None:
+            data = b""
+        else:
+            data = bytes(data)
+        tp = self._isotp_transport(channel, to_controller, from_controller)
+        tp.send_message(UdsMessage(payload=bytearray(data),
+                                   addressing_type=AddressingType.PHYSICAL))
+        return True
+
+    # -- interop data store: persist a procedure's outputs keyed by board id --
+    def _store(self):
+        if self._datastore is None:
+            from uds_local.datastore import DataStore
+            self._datastore = DataStore()
+        return self._datastore
+
+    def _primary_board_id(self):
+        """Board serial (DID 0xF013) of the first node this run reached; None if
+        unread. Keys stored outputs by the physical board (like the immobilizer)."""
+        for _cfg, sess in self._nodes.values():
+            with contextlib.suppress(Exception):
+                raw = bytes(sess.read_did(0xF013))  # BOARD_SERIAL_NUMBER
+                sn = raw.decode("ascii", "replace").rstrip("\x00").strip()
+                if sn:
+                    return sn
+        return None
+
+    def store_outputs(self, outputs):
+        if not outputs:
+            return
+        board_id = self._primary_board_id()
+        if not board_id:
+            return
+        from uds_local.datastore import json_safe
+        self._store().update(board_id, "outputs", json_safe(outputs))
+
+    def ensure_application_state(self, node_name, state):
+        """Drive a node into its BOOTLOADER or APPLICATION state
+        (vehiclecontrols.EnsureApplicationState). Reuses the SAME UdsSession bootloader
+        handover as the flasher (dfu.py / flash_scripts step_ecu_reset +
+        step_wait_for_bootloader): ecu_reset, then wait_for_bootloader floods
+        TesterPresent through the reboot so the bootloader holds (update.img
+        enter_bootloader_v0) -- that's what makes bootloader-context DIDs
+        (STORE-DATA-BOOT package identity) readable. APPLICATION just resets: with no
+        TP flood the bootloader boots on into the app. Tracked so an already-in-state
+        node isn't needlessly reset; None / ESP are no-ops."""
+        if not state or node_name.upper() == "ESP":
+            return
+        want_bl = "BOOT" in str(state).upper()
+        key = node_name.upper()
+        if want_bl == (key in self._bootloader):
+            return  # already in the requested state
+        _cfg, sess = self._node(node_name)
+        sess.ecu_reset_no_wait(0x01)          # == flash step_ecu_reset
+        if want_bl:
+            sess.wait_for_bootloader()        # == flash step_wait_for_bootloader
+            self._bootloader.add(key)
+        else:
+            self._bootloader.discard(key)     # reset boots on into the app
+
+    def close(self):
+        for _cfg, sess in self._nodes.values():
+            with contextlib.suppress(Exception):
+                sess.stop_tester_present()
+            with contextlib.suppress(Exception):
+                sess.__exit__()
+        self._nodes.clear()
+        for bus, notifier, _cache in self._can.values():
+            with contextlib.suppress(Exception):
+                notifier.stop()
+            with contextlib.suppress(Exception):
+                bus.shutdown()
+        self._can.clear()
+        for bus, notifier, _tp in self._isotp.values():
+            with contextlib.suppress(Exception):
+                notifier.stop()
+            with contextlib.suppress(Exception):
+                bus.shutdown()
+        self._isotp.clear()
+
+
+class _StubUds:
+    """No-op UDS node (ESP on a conversion bench) -- every service is a nop."""
+    def tester_present(self): pass
+    def diagnostic_session(self, *_a, **_k): pass
+    def security_access(self, *_a, **_k): pass
+    def routine_control(self, *_a, **_k): return b""
+    def read_data(self, *_a, **_k): return b""
+    def write_data(self, *_a, **_k): pass
+    def io_control(self, *_a, **_k): return b""
+    def ecu_reset(self, *_a, **_k): pass
+    def clear_dtcs(self, *_a, **_k): pass
+    def read_dtcs(self, *_a, **_k): return {}
+
+
+class _StubOdx:
+    """No-op odx node (ESP)."""
+    def start_routine(self, *_a, **_k): return b""
+    def stop_routine(self, *_a, **_k): return b""
+    def request_results(self, *_a, **_k): return {}
+    def start_and_wait(self, *_a, **_k): return {}
+    def read_data(self, *_a, **_k): return {}
+    def write_data(self, *_a, **_k): pass
+    def get_value(self, routine, param_name, param_value, parsed): return param_value
+
+
+class _UdsAdapter:
+    """Maps ODIN uds.* (raw payloads) onto uds_local.UdsSession."""
+    _RTYPE = {"START_ROUTINE": 0x01, "STOP_ROUTINE": 0x02,
+              "REQUEST_RESULTS": 0x03, "REQUEST_ROUTINE_RESULTS": 0x03}
+    _SESSION = {"DEFAULT_SESSION": 0x01, "PROGRAMMING_SESSION": 0x02,
+                "EXTENDED_DIAGNOSTIC_SESSION": 0x03,
+                "SAFETY_SYSTEM_DIAGNOSTIC_SESSION": 0x04}
+    _RESET = {"HARD_RESET": 0x01, "KEY_OFF_ON_RESET": 0x02,
+              "KEY_OFF_ON": 0x02, "SOFT_RESET": 0x03}
+    _IOCP = {"RETURN_CONTROL_TO_ECU": 0x00, "RESET_TO_DEFAULT": 0x01,
+             "FREEZE_CURRENT_STATE": 0x02, "SHORT_TERM_ADJUST": 0x03,
+             "SHORT_TERM_ADJUSTMENT": 0x03}
+
+    def __init__(self, sess):
+        self.sess = sess
+
+    def tester_present(self):
+        pass  # UdsSession runs its own keep-alive thread
+
+    def diagnostic_session(self, session_type):
+        s = str(session_type).upper()
+        mode = self._SESSION.get(s, 0x03 if "EXTENDED" in s else 0x01)
+        self.sess.diagnostic_session(mode)
+
+    def security_access(self, security_level):
+        self.sess.security_access(level_idx=0, seed_level=_trailing_int(security_level, 5))
+
+    def routine_control(self, routine_id, payload=None, routine_type=None):
+        arg = bytes.fromhex(payload) if isinstance(payload, str) and payload else b""
+        sub = self._RTYPE.get(str(routine_type).upper(), 0x01)
+        return self.sess.routine_control(_to_int(routine_id), arg=arg, subtype=sub)
+
+    def read_data(self, data_id):
+        return self.sess.read_did(_to_int(data_id))
+
+    def write_data(self, data_id, payload):
+        data = bytes.fromhex(payload) if isinstance(payload, str) else bytes(payload or b"")
+        self.sess.write_did(_to_int(data_id), data)
+
+    def io_control(self, control_id, control_type=None, payload=None):
+        cp = self._IOCP.get(str(control_type).upper(), 0x03)
+        data = (bytes.fromhex(payload) if isinstance(payload, str) and payload
+                else bytes(payload or b""))
+        return self.sess.io_control(_to_int(control_id), cp, data)
+
+    def ecu_reset(self, reset_type, response_required=True):
+        rt = self._RESET.get(str(reset_type).upper(), 0x01)
+        if response_required is False:
+            self.sess.ecu_reset_no_wait(rt)
+        else:
+            self.sess.ecu_reset(rt)
+
+    def clear_dtcs(self, dtc_mask=None):
+        # dtc_mask is often a status name (e.g. 'TestFailed'); clear-all is the
+        # safe generalization since the group defaults to 0xFFFFFF.
+        try:
+            group = _to_int(dtc_mask) if dtc_mask not in (None, "") else 0xFFFFFF
+        except ValueError:
+            group = 0xFFFFFF
+        self.sess.clear_dtc(group)
+
+    def read_dtcs(self, dtc_mask=None):
+        try:
+            mask = _to_int(dtc_mask) if dtc_mask not in (None, "") else 0xFF
+        except ValueError:
+            mask = 0xFF
+        return self.sess.read_dtcs(mask)
+
+
+class _OdxAdapter:
+    """Maps ODIN odx.* (NAMED params) onto UdsSession using the node's ODJ
+    (NodeConfig.routines/.dids) + odj_codec to resolve name->id, encode requests,
+    and decode responses per the ODJ FieldSpecs. Generalizes resolver_cal.py."""
+
+    def __init__(self, sess, cfg):
+        self.sess = sess
+        self.cfg = cfg
+
+    def _routine(self, name):
+        rt = self.cfg.routines.get(name)
+        if rt is None:
+            raise ProcedureError(f"odx routine {name!r} not in {self.cfg.name} ODJ")
+        return rt
+
+    def _did(self, name):
+        d = self.cfg.dids.get(name)
+        if d is None:
+            raise ProcedureError(f"odx DID {name!r} not in {self.cfg.name} ODJ")
+        return d
+
+    def _auth(self, sub) -> None:
+        """Run SecurityAccess for a routine/DID subspec's ODJ-declared security level.
+        Tesla's odx layer does this IMPLICITLY -- these graphs carry no explicit
+        uds.UdsSecurityAccess node before an odx routine, so a security-gated routine
+        returns NRC 0x33 (securityAccessDenied) without it. The level comes straight
+        from the ODJ (e.g. PMR CAN_COMM_SELF_TEST = 5); the ODJ carries no session, so
+        we use the EXTENDED diagnostic session (0x03) -- where security-gated DIAGNOSTIC
+        routines/DIDs run. The PROGRAMMING session (0x02) would push the ECU into a
+        flash/bootloader mode that stops normal app comms -- which for a bus self-test
+        reads as 'not connected' and starves the bus of ACKs (ENOBUFS). Flashing graphs
+        set programming explicitly via uds.* nodes. Idempotent (re-request -> NRC 0x35)."""
+        level = getattr(sub, "security_level", 0) if sub else 0
+        if level:
+            self.sess.diagnostic_session(0x03)  # extended diagnostic session
+            self.sess.security_access(seed_level=level)
+
+    def start_routine(self, routine, params=None):
+        from uds_local.odj_codec import encode_request
+        rt = self._routine(routine)
+        self._auth(rt.start)
+        return self.sess.routine_control(
+            rt.hex_id, arg=encode_request(rt.start, params or {}), subtype=0x01)
+
+    def stop_routine(self, routine, params=None):
+        from uds_local.odj_codec import encode_request
+        rt = self._routine(routine)
+        self._auth(rt.stop)
+        return self.sess.routine_control(
+            rt.hex_id, arg=encode_request(rt.stop, params or {}), subtype=0x02)
+
+    def request_results(self, routine, params=None):
+        from uds_local.odj_codec import decode_response, encode_request
+        rt = self._routine(routine)
+        self._auth(rt.results)
+        raw = self.sess.routine_control(
+            rt.hex_id, arg=encode_request(rt.results, params or {}), subtype=0x03)
+        return decode_response(rt.results, raw, parsed=True)
+
+    def start_and_wait(self, routine, status_param, in_progress, timeout,
+                       input_parameters=None, stop_routine=False,
+                       cancel=None, time_scale=1.0):
+        from uds_local.odj_codec import decode_response, encode_request
+        rt = self._routine(routine)
+        # Auth once before the start; the results polls reuse the unlocked session.
+        self._auth(rt.start)
+        self.sess.routine_control(
+            rt.hex_id, arg=encode_request(rt.start, input_parameters or {}), subtype=0x01)
+        in_prog = in_progress if isinstance(in_progress, (list, tuple, set)) else [in_progress]
+        deadline = time.monotonic() + (timeout or 0) * (time_scale or 0.0)
+        results: dict = {}
+        first = True
+        while first or time.monotonic() < deadline:
+            first = False
+            raw = self.sess.routine_control(rt.hex_id, subtype=0x03)
+            results = decode_response(rt.results, raw, parsed=True)
+            if status_param is None or results.get(status_param) not in in_prog:
+                break
+            if cancel is not None and cancel.is_set():
+                break
+            time.sleep(0.2 * (time_scale or 0.0))
+        if stop_routine:
+            with contextlib.suppress(Exception):
+                self.sess.routine_control(rt.hex_id, subtype=0x02)
+        return results
+
+    def read_data(self, data_name):
+        from uds_local.odj_codec import decode_response
+        d = self._did(data_name)
+        self._auth(d.read)
+        return decode_response(d.read, self.sess.read_did(d.hex_id), parsed=True)
+
+    def write_data(self, data_name, data):
+        from uds_local.odj_codec import encode_request
+        d = self._did(data_name)
+        self._auth(d.write)
+        self.sess.write_did(d.hex_id, encode_request(d.write, data or {}))
+
+    def get_value(self, routine, param_name, param_value, parsed):
+        """Re-derive one results param's parsed/raw form from its ODJ FieldSpec."""
+        from uds_local.odj_codec import decode_field  # noqa: F401  (kept for symmetry)
+        rt = self.cfg.routines.get(routine)
+        fs = rt.results.output.get(param_name) if rt and rt.results else None
+        if fs is None or not fs.enum_map:
+            return param_value
+        if parsed:
+            if {k.upper() for k in fs.enum_map} == {"TRUE", "FALSE"}:
+                return bool(param_value)
+            inverse = {v: k for k, v in fs.enum_map.items()}
+            return inverse.get(param_value, param_value)
+        return fs.enum_map.get(param_value, param_value)  # name -> raw number
+
+
+# =====================================================================================
+# the engine
+# =====================================================================================
+class Engine:
+    def __init__(self, backend: Backend, bundle: Path, verbose: bool = False,
+                 time_scale: float = 0.0, loop_pause: float = 0.01, max_loops: int = 50,
+                 on_event=None):
+        self.backend = backend
+        self.bundle = bundle
+        self.verbose = verbose
+        self._time_scale = time_scale   # 0 => don't actually sleep (fast mock)
+        self._loop_pause = loop_pause
+        self._max_loops = max_loops
+        # Optional run-progress listener: on_event(kind, payload) is called for
+        # 'trace' (node execution steps) and 'metric' (each captured metric) so a
+        # CLI/web caller can stream progress instead of waiting silently. A listener
+        # error never crashes the run. See scripts/odin_service.py.
+        self._on_event = on_event
+
+    # -- entry points --
+    # A bare task-wrapper's entry node is one of these single subnet-call types (no
+    # networks.Enter): its `inputs` bind to sibling networks.Input nodes in the wrapper
+    # frame, then it invokes the referenced/script graph.
+    _WRAPPER_ENTRY_TYPES = (
+        "networks.RunReferencedSubnetwork",
+        "scripts.RunScriptTest",
+        "networks.DynamicallyReferencedSubnetwork",
+    )
+
+    def run_procedure(self, relbase: str) -> RunResult:
+        result = self._run_child_graph(load_graph(self.bundle, relbase), {}, depth=0)
+        with contextlib.suppress(Exception):
+            self.backend.store_outputs(result.outputs)  # persist keyed by board id
+        return result
+
+    def _run_child_graph(self, graph: dict, inputs: dict, depth: int) -> RunResult:
+        """Run a loaded graph regardless of form: a wired graph (has networks.Enter)
+        runs directly; a bare task-wrapper (a single RunReferencedSubnetwork /
+        RunScriptTest / DynamicallyReferencedSubnetwork node, no Enter) invokes its
+        subnet in a wrapper frame so `<Input>.value` connections resolve."""
+        if self._has(graph, "networks.Enter"):
+            return self.run_graph(graph, inputs, depth=depth)
+        tname = next((self._find_opt(graph, t) for t in self._WRAPPER_ENTRY_TYPES
+                      if self._find_opt(graph, t)), None)
+        if tname is None:
+            return self.run_graph(graph, inputs, depth=depth)  # no Enter -> clear error
+        frame = Frame(graph=graph, inputs=inputs, depth=depth)
+        node = graph[tname]
+        self._log(depth, f"task {tname} -> {self._resolve_basename(frame, node)}")
+        return self._invoke_subnet(frame, tname, node)
+
+    def run_graph(self, graph: dict, inputs: dict, depth: int = 0) -> RunResult:
+        frame = Frame(graph=graph, inputs=inputs, depth=depth)
+        code = 1
+        try:
+            self._fire(frame, self._graph_start(graph))
+        except GraphExit as ge:
+            code = ge.code
+        finally:
+            frame.cancel.set()
+            for t in frame.threads:
+                t.join(timeout=0.5)
+        self._collect_outputs(frame)
+        return RunResult(code, frame.metrics, frame.outputs)
+
+    def _graph_start(self, graph: dict):
+        """The graph's entry control field. Wired graphs (incl. inline Enter/Exit
+        subnets) start at networks.Enter.start; inline Slot/Signal subnets start at
+        the networks.Slot node, which relays into the inner graph via its `signal`."""
+        enter = self._find_opt(graph, "networks.Enter")
+        if enter is not None:
+            return graph[enter].get("start")
+        slot = self._find_opt(graph, "networks.Slot")
+        if slot is not None:
+            return graph[slot].get("signal")
+        raise ProcedureError("graph has no networks.Enter or networks.Slot node")
+
+    def _collect_outputs(self, frame: Frame) -> None:
+        """Materialize a graph's networks.Output ports (pulled from their source) into
+        frame.outputs. SetOutput nodes have already written theirs during control flow;
+        setdefault lets an imperative SetOutput win over a declarative Output of the
+        same name. Each pull is best-effort: a graph that exited early may not have
+        computed every source node."""
+        for oname, onode in frame.graph.items():
+            if isinstance(onode, dict) and onode.get("type") == "networks.Output":
+                with contextlib.suppress(Exception):
+                    frame.outputs.setdefault(oname, self._pull(frame, onode.get("port")))
+
+    def _invoke_subnet(self, frame: Frame, name: str, node: dict) -> RunResult:
+        """Run a referenced/script subnetwork: resolve its basename, bind its inputs by
+        pulling each mapping (literal or connection) IN THE CALLER's frame, run the child
+        graph in its own frame, and stash the RunResult. Child metrics bubble up so a
+        single report spans the whole tree; child GraphExit does NOT unwind the caller.
+        The child may itself be a wired graph or a bare task-wrapper."""
+        base = self._resolve_basename(frame, node)
+        child = load_graph(self.bundle, base)
+        child_inputs = {k: self._pull(frame, v)
+                        for k, v in (node.get("inputs") or {}).items()}
+        self._log(frame.depth, f"call {name} -> {base} inputs={child_inputs}")
+        result = self._run_child_graph(child, child_inputs, depth=frame.depth + 1)
+        frame.scratch[name] = result
+        frame.metrics.extend(result.metrics)
+        self._log(frame.depth, f"     {base} exit={result.exit_code} outputs={result.outputs}")
+        return result
+
+    def _resolve_basename(self, frame: Frame, node: dict):
+        """The referenced graph basename, however this subnet-call node names it:
+        `basename` (Referenced/RunReferencedSubnetwork), `script_name` (RunScriptTest,
+        a bare string), or `name` (DynamicallyReferencedSubnetwork). A dict value is a
+        data field pulled in the caller frame (a runtime-resolved basename)."""
+        b = None
+        for key in ("basename", "script_name", "name"):
+            if node.get(key) is not None:
+                b = node[key]
+                break
+        return self._pull(frame, b) if isinstance(b, dict) else b
+
+    # -- networks.Subnetwork: an INLINE-nested subgraph. Unlike ReferencedSubnetwork
+    # (which loads another file), the node's own dict IS the child graph: every non-
+    # reserved key is an inner node, and inner connections are prefixed with this node's
+    # name (`<subnet>.<inner>.<port>`). Lift the inner nodes into a child graph, strip
+    # the prefix, and reuse the same execution path as a referenced subnetwork.
+    _RESERVED_SUBNET_KEYS = frozenset(
+        {"type", "position", "slots", "signals", "inputs", "outputs", "comment"})
+
+    def _ctrl_networks_Subnetwork(self, frame, name, node, in_port):
+        self._invoke_inline_subnet(frame, name, node)
+        sig = (node.get("signals") or {}).get("exit")
+        if sig:
+            self._fire(frame, sig)
+
+    def _invoke_inline_subnet(self, frame: Frame, name: str, node: dict) -> RunResult:
+        child = {k: self._deprefix(v, name + ".")
+                 for k, v in node.items()
+                 if k not in self._RESERVED_SUBNET_KEYS
+                 and isinstance(v, dict) and "type" in v}
+        child_inputs = {k: self._pull(frame, v)
+                        for k, v in (node.get("inputs") or {}).items()}
+        self._log(frame.depth, f"inline-subnet {name} inputs={child_inputs}")
+        result = self.run_graph(child, child_inputs, depth=frame.depth + 1)
+        frame.scratch[name] = result
+        frame.metrics.extend(result.metrics)
+        self._log(frame.depth, f"     {name} exit={result.exit_code} outputs={result.outputs}")
+        return result
+
+    @classmethod
+    def _deprefix(cls, obj, prefix):
+        """Deep-copy a node/field, stripping `prefix` from every 'connection' string so
+        the lifted inner nodes reference each other by bare `<inner>.<port>` (what
+        run_graph expects). Parent-scope connections (which don't carry the prefix) are
+        left untouched -- but inline subnets keep all inner refs prefixed."""
+        if isinstance(obj, dict):
+            out = {}
+            for k, v in obj.items():
+                if k == "connection" and isinstance(v, str) and v.startswith(prefix):
+                    out[k] = v[len(prefix):]
+                else:
+                    out[k] = cls._deprefix(v, prefix)
+            return out
+        if isinstance(obj, list):
+            return [cls._deprefix(x, prefix) for x in obj]
+        return obj
+
+    # -- inline-subnet Slot/Signal plumbing (the alternative to Enter/Exit). Slot is the
+    # inner entry: relays the parent's slot into the inner graph via `signal`. Signal is
+    # the exit relay: a leaf whose firing ends its branch; the parent's `signals.exit` is
+    # fired by _ctrl_networks_Subnetwork after the inner run completes.
+    def _ctrl_networks_Slot(self, frame, name, node, in_port):
+        self._fire(frame, node.get("signal"))
+
+    def _ctrl_networks_Signal(self, frame, name, node, in_port):
+        pass  # exit relay -- see _ctrl_networks_Subnetwork
+
+    def _ctrl_networks_Cancelled(self, frame, name, node, in_port):
+        # Registers a handler fired only on operator cancellation, which this runner
+        # never raises mid-graph -> the `cancelled` branch is inert on a bench.
+        pass
+
+    # -- control/data plumbing --
+    def _fire(self, frame: Frame, ctrl_field) -> None:
+        if not ctrl_field or "connection" not in ctrl_field:
+            return
+        # Split on the FIRST dot: node names never contain '.', so the remainder is the
+        # full port path -- 'run' for a normal node, 'slots.enter' into a subnetwork.
+        node_name, _, in_port = ctrl_field["connection"].partition(".")
+        node = frame.graph[node_name]
+        handler = getattr(self, "_ctrl_" + node["type"].replace(".", "_"), None)
+        if handler is None:
+            raise ProcedureError(f"no control handler for {node['type']} ({node_name})")
+        self._log(frame.depth, f"run  {node_name} [{node['type']}] :{in_port}")
+        handler(frame, node_name, node, in_port)
+
+    def _pull(self, frame: Frame, fld):
+        if not isinstance(fld, dict):
+            return fld
+        if "connection" in fld:
+            node_name, _, port = fld["connection"].partition(".")  # first dot: see _fire
+            node = frame.graph[node_name]
+            handler = getattr(self, "_data_" + node["type"].replace(".", "_"), None)
+            if handler is None:
+                raise ProcedureError(f"no data handler for {node['type']} ({node_name})")
+            return handler(frame, node_name, node, port)
+        if "value" in fld:
+            return fld["value"]
+        return None
+
+    @staticmethod
+    def _find_opt(graph, ntype):
+        for name, node in graph.items():
+            if isinstance(node, dict) and node.get("type") == ntype:
+                return name
+        return None
+
+    @staticmethod
+    def _has(graph, ntype):
+        return any(isinstance(n, dict) and n.get("type") == ntype for n in graph.values())
+
+    # NOTE: comparator/operator enum is a best-guess (0:== 1:!= 2:< 3:<= 4:> 5:>=).
+    # cid.GetDataValueUntil uses operator (0 seen = equals); can.* uses comparator
+    # (4 seen on axleSpeed_>_560). Confirm on the bench if a compare misbehaves.
+    @staticmethod
+    def _cmp(op, a, b) -> bool:
+        if a is None:
+            return False
+        try:
+            return [lambda: a == b, lambda: a != b, lambda: a < b,
+                    lambda: a <= b, lambda: a > b, lambda: a >= b][int(op or 0)]()
+        except TypeError:
+            return a == b
+
+    def _log(self, depth, msg):
+        if self.verbose:
+            print("  " * (depth + 1) + msg)
+        if self._on_event is not None:
+            self._emit("trace", {"depth": depth, "message": msg})
+
+    def _emit(self, kind, payload) -> None:
+        """Push a run event (kind in {'trace','metric'}) to the optional on_event
+        listener. A listener error must never crash the run."""
+        if self._on_event is None:
+            return
+        with contextlib.suppress(Exception):
+            self._on_event(kind, payload)
+
+    def _sleep(self, seconds):
+        if self._time_scale and seconds:
+            time.sleep(seconds * self._time_scale)
+
+    # ---------------- control handlers ----------------
+    def _ctrl_networks_Exit(self, frame, name, node, in_port):
+        code = self._pull(frame, node.get("exit_code"))
+        with contextlib.suppress(TypeError, ValueError):
+            code = int(code)
+        raise GraphExit(code)
+
+    def _ctrl_networks_Set(self, frame, name, node, in_port):
+        var = self._pull(frame, node["variable"])
+        frame.vars[var] = self._pull(frame, node["value"])
+        self._log(frame.depth, f"     set {var} = {frame.vars[var]!r}")
+        self._fire(frame, node.get("saved"))
+
+    def _ctrl_networks_SetOutput(self, frame, name, node, in_port):
+        frame.outputs[node["key"]] = self._pull(frame, node.get("value"))
+        self._log(frame.depth, f"     output[{node['key']!r}] = {frame.outputs[node['key']]!r}")
+        self._fire(frame, node.get("finished"))
+
+    def _ctrl_networks_AppendOutput(self, frame, name, node, in_port):
+        # Like SetOutput but accumulates into a LIST-valued output (fired repeatedly).
+        key = node["key"]
+        bucket = frame.outputs.setdefault(key, [])
+        if not isinstance(bucket, list):
+            bucket = frame.outputs[key] = [bucket]
+        bucket.append(self._pull(frame, node.get("value")))
+        self._fire(frame, node.get("finished"))
+
+    # -- referenced subnetworks (THE keystone: 633/661 procs call another graph inline).
+    # Entered via a <node>.slots.<slot> control connection; on child exit, fire the single
+    # `exit` signal. Child outputs are read as data via <node>.outputs.<name>. Both the
+    # inline ReferencedSubnetwork and RunReferencedSubnetwork forms share this shape.
+    def _ctrl_networks_ReferencedSubnetwork(self, frame, name, node, in_port):
+        self._invoke_subnet(frame, name, node)
+        sig = (node.get("signals") or {}).get("exit")
+        if sig:
+            self._fire(frame, sig)
+
+    _ctrl_networks_RunReferencedSubnetwork = _ctrl_networks_ReferencedSubnetwork
+
+    def _data_networks_ReferencedSubnetwork(self, frame, name, node, port):
+        result = frame.scratch.get(name)
+        if result is None:
+            return None
+        oname = port.split(".", 1)[1] if port.startswith("outputs.") else port
+        if oname == "exit_code":
+            return result.exit_code
+        return result.outputs.get(oname)
+
+    _data_networks_RunReferencedSubnetwork = _data_networks_ReferencedSubnetwork
+    # networks.Subnetwork outputs are read the same way (<node>.outputs.<name>).
+    _data_networks_Subnetwork = _data_networks_ReferencedSubnetwork
+
+    # -- scripts.RunScriptTest: run a networks/*/scripts/ graph. Same call shape as a
+    # referenced subnetwork (basename = `script_name`, a bare string); as an inline node
+    # it continues via `done`, as a bare-task entry it IS the wrapper's entry node.
+    def _ctrl_scripts_RunScriptTest(self, frame, name, node, in_port):
+        self._invoke_subnet(frame, name, node)
+        sig = (node.get("signals") or {}).get("exit")
+        if sig:
+            self._fire(frame, sig)
+        self._fire(frame, node.get("done"))
+
+    _data_scripts_RunScriptTest = _data_networks_ReferencedSubnetwork
+
+    # -- networks.DynamicallyReferencedSubnetwork: the target graph basename is resolved
+    # at run time from `name` (a literal or a connection, e.g. ForEach.item). No slots;
+    # continues via `done`. Child outputs (rare) read the same as a referenced subnet.
+    def _ctrl_networks_DynamicallyReferencedSubnetwork(self, frame, name, node, in_port):
+        self._invoke_subnet(frame, name, node)
+        sig = (node.get("signals") or {}).get("exit")
+        if sig:
+            self._fire(frame, sig)
+        self._fire(frame, node.get("done"))
+
+    _data_networks_DynamicallyReferencedSubnetwork = _data_networks_ReferencedSubnetwork
+
+    def _ctrl_control_IfThen(self, frame, name, node, in_port):
+        branch = "if_true" if self._pull(frame, node["expr"]) else "if_false"
+        self._fire(frame, node.get(branch))
+
+    def _ctrl_control_Split(self, frame, name, node, in_port):
+        t = threading.Thread(target=self._branch, args=(frame, node.get("a")), daemon=True)
+        frame.threads.append(t)
+        t.start()
+        self._fire(frame, node.get("b"))
+
+    def _branch(self, frame, ctrl_field):
+        try:
+            self._fire(frame, ctrl_field)
+        except GraphExit:
+            pass
+        except _BreakLoop:
+            pass
+        except Exception as e:  # noqa: BLE001  (a concurrent branch dying must not crash the run)
+            self._log(frame.depth, f"     [split branch error] {e}")
+
+    def _run_body(self, frame, ctrl_field) -> bool:
+        """Fire a loop body; return True if a control.Break asked the loop to stop."""
+        try:
+            self._fire(frame, ctrl_field)
+            return False
+        except _BreakLoop:
+            return True
+
+    def _ctrl_control_Break(self, frame, name, node, in_port):
+        raise _BreakLoop
+
+    def _ctrl_control_WhileLoop(self, frame, name, node, in_port):
+        cond = node.get("condition", {}).get("value", "True")
+        i = 0
+        while not frame.cancel.is_set():
+            if cond != "True" and not self._pull(frame, node["condition"]):
+                break
+            if self._run_body(frame, node.get("run_body")):
+                break
+            i += 1
+            if self._max_loops and i >= self._max_loops:
+                break
+            if frame.cancel.wait(self._loop_pause):
+                break
+
+    def _ctrl_control_TryExceptAll(self, frame, name, node, in_port):
+        try:
+            self._fire(frame, node.get("try_body"))
+            self._fire(frame, node.get("else_body"))
+        except GraphExit:
+            raise
+        except Exception as e:  # noqa: BLE001
+            frame.scratch.setdefault(name, {})["exception"] = e
+            self._fire(frame, node.get("except_body"))
+        finally:
+            self._fire(frame, node.get("finally_body"))
+
+    def _ctrl_control_TryExcept(self, frame, name, node, in_port):
+        # Typed catch (exception_class is an ODIN/Python class path). Tesla's names
+        # (e.g. odin.core.uds.exceptions.UdsEcuError) don't map to our exception
+        # classes, so we catch broadly -- matching the intent (swallow expected UDS/
+        # ISO-TP errors during interop). GraphExit still propagates.
+        try:
+            self._fire(frame, node.get("try_body"))
+            self._fire(frame, node.get("else_body"))
+        except GraphExit:
+            raise
+        except Exception as e:  # noqa: BLE001
+            frame.scratch.setdefault(name, {})["exception"] = e
+            self._fire(frame, node.get("except_body"))
+        finally:
+            self._fire(frame, node.get("finally_body"))
+
+    def _data_control_TryExcept(self, frame, name, node, port):
+        return frame.scratch.get(name, {}).get("exception")
+
+    # -- vehiclecontrols.* (power / app-state orchestration; bench = assume state) --
+    def _ctrl_vehiclecontrols_PowerContext(self, frame, name, node, in_port):
+        # Ensure the power state (bench no-op by default), run the protected body,
+        # then continue via `done`. `failure` is only for real power-acquisition
+        # faults, which the bench never raises. Body may itself Exit the graph.
+        self.backend.ensure_power_state(self._pull(frame, node.get("power_state")))
+        self._fire(frame, node.get("body"))
+        self._fire(frame, node.get("done"))
+
+    def _ctrl_vehiclecontrols_EnsureApplicationState(self, frame, name, node, in_port):
+        self.backend.ensure_application_state(
+            self._pull(frame, node.get("node_name")),
+            self._pull(frame, node.get("application_state")))
+        self._fire(frame, node.get("done"))
+
+    def _ctrl_vehiclecontrols_EnsurePowerState(self, frame, name, node, in_port):
+        self.backend.ensure_power_state(self._pull(frame, node.get("power_state")))
+        self._fire(frame, node.get("done"))
+
+    def _ctrl_vehiclecontrols_McuScreenOn(self, frame, name, node, in_port):
+        self._fire(frame, node.get("done"))
+
+    def _ctrl_debug_Sleep(self, frame, name, node, in_port):
+        self._sleep(self._pull(frame, node.get("seconds")) or 0)
+        self._fire(frame, node.get("done"))
+
+    def _ctrl_debug_Print(self, frame, name, node, in_port):
+        self._log(frame.depth, f"     print {self._pull(frame, node.get('value'))!r}")
+        self._fire(frame, node.get("done"))
+
+    def _ctrl_reporting_CaptureMetric(self, frame, name, node, in_port):
+        metric = {
+            "metric": self._pull(frame, node.get("metric_name")),
+            "value": self._pull(frame, node.get("value")),
+            "result_code": self._pull(frame, node.get("result_code")),
+            "expected": self._pull(frame, node.get("expected_value")),
+        }
+        frame.metrics.append(metric)
+        self._log(frame.depth,
+                  f"     metric {metric['metric']} = {metric['value']!r} rc={metric['result_code']}")
+        self._emit("metric", metric)
+        self._fire(frame, node.get("done"))
+
+    def _ctrl_reporting_CaptureConnectorInfoLookup(self, frame, name, node, in_port):
+        # The task-terminal node that ties a connector-info file to the procedure's
+        # exit_code. The real connector-DB lookup needs Tesla's manufacturing data;
+        # on a bench we record the exit_code + file as a metric and continue.
+        code = self._pull(frame, node.get("exit_code"))
+        frame.metrics.append({
+            "metric": "ConnectorInfoLookup",
+            "value": self._pull(frame, node.get("file_name")),
+            "result_code": code,
+            "expected": None,
+        })
+        self._emit("metric", frame.metrics[-1])
+        self._fire(frame, node.get("done"))
+
+    def _ctrl_cid_GetDataValueUntil(self, frame, name, node, in_port):
+        dn = self._pull(frame, node["data_name"])
+        want = self._pull(frame, node["pass_value"])
+        op = self._pull(frame, node.get("operator")) or 0
+        timeout = self._pull(frame, node.get("timeout")) or 10
+        poll = self._pull(frame, node.get("sleep")) or 0.25
+        deadline = time.monotonic() + timeout * (self._time_scale or 0.0)
+        v = None
+        first = True
+        while first or time.monotonic() < deadline:
+            first = False
+            v = self.backend.cid_get(dn)
+            if self._cmp(op, v, want):
+                self._log(frame.depth, f"     cid {dn}={v!r} == {want!r} -> passed")
+                return self._fire(frame, node.get("passed"))
+            if frame.cancel.is_set():
+                break
+            self._sleep(poll)
+        self._log(frame.depth, f"     cid {dn}={v!r} != {want!r} -> timed_out")
+        self._fire(frame, node.get("timed_out"))
+
+    # ---- cid.* data-value store (read-your-writes) ----
+    def _ctrl_cid_SetDataValue(self, frame, name, node, in_port):
+        self.backend.cid_set(self._pull(frame, node["data_name"]),
+                             self._pull(frame, node.get("value")))
+        self._fire(frame, node.get("done"))
+
+    def _ctrl_cid_SaveData(self, frame, name, node, in_port):
+        self.backend.cid_save(self._pull(frame, node.get("filename")),
+                             self._pull(frame, node.get("data")))
+        self._fire(frame, node.get("done"))
+
+    # ---- cid.* filesystem ops (real data from the firmware dump, read-only) ----
+    def _ctrl_cid_GetDirectoryContents(self, frame, name, node, in_port):
+        listing = self.backend.cid_list_dir(
+            self._pull(frame, node.get("directory")),
+            show_hidden=bool(self._pull(frame, node.get("show_hidden"))),
+            details=bool(self._pull(frame, node.get("details"))))
+        frame.scratch[name] = {"result": listing, "error": ""}
+        self._fire(frame, node.get("done"))
+
+    def _ctrl_cid_Grep(self, frame, name, node, in_port):
+        matches = self.backend.cid_grep(self._pull(frame, node.get("pattern")),
+                                        self._pull(frame, node.get("file_location")),
+                                        self._pull(frame, node.get("args")))
+        frame.scratch[name] = {"stdout": "\n".join(matches), "stderr": "",
+                               "matches": matches}
+        self._fire(frame, node.get("done"))
+
+    def _ctrl_cid_GetDiskFree(self, frame, name, node, in_port):
+        frame.scratch[name] = self.backend.cid_disk_free(
+            self._pull(frame, node.get("mountpoint")))
+        self._fire(frame, node.get("done"))
+
+    # ---- cid.* shell execution (stubbed: dump binaries can't run) ----
+    def _cid_exec(self, frame, name, node, kind):
+        frame.scratch[name] = self.backend.cid_execute(
+            kind=kind,
+            path=self._pull(frame, node.get("path")),
+            command=self._pull(frame, node.get("command")),
+            args=self._pull(frame, node.get("args")),
+            user=self._pull(frame, node.get("user")))
+        self._fire(frame, node.get("done"))
+
+    def _ctrl_cid_ExecuteApplication(self, frame, name, node, in_port):
+        self._cid_exec(frame, name, node, "application")
+
+    def _ctrl_cid_ExecuteScript(self, frame, name, node, in_port):
+        self._cid_exec(frame, name, node, "script")
+
+    def _ctrl_cid_CidCommand(self, frame, name, node, in_port):
+        self._cid_exec(frame, name, node, "command")
+
+    # ---- cid.* no-op control (service/reboot/process; nothing to do on a bench) ----
+    def _ctrl_cid_SvCommand(self, frame, name, node, in_port):
+        self._fire(frame, node.get("done"))
+
+    def _ctrl_cid_CheckProcess(self, frame, name, node, in_port):
+        self._fire(frame, node.get("done"))
+
+    def _ctrl_cid_RebootCid(self, frame, name, node, in_port):
+        self._fire(frame, node.get("done"))
+
+    def _ctrl_cid_ClearCache(self, frame, name, node, in_port):
+        self._fire(frame, node.get("done"))
+
+    def _ctrl_cid_EmitRebootGateway(self, frame, name, node, in_port):
+        self._fire(frame, node.get("done"))
+
+    def _ctrl_cid_SaveAuthoredPopup(self, frame, name, node, in_port):
+        # Persist an authored popup blob into the CID data store (read-your-writes),
+        # keyed by identifier; record success and continue.
+        self.backend.cid_save(self._pull(frame, node.get("identifier")),
+                              self._pull(frame, node.get("data")))
+        frame.scratch[name] = {"success": True}
+        self._fire(frame, node.get("done"))
+
+    def _data_cid_SaveAuthoredPopup(self, frame, name, node, port):
+        return frame.scratch.get(name, {}).get("success", True)
+
+    # ---- messages.* (ODIN framework UI/IPC messages; bench = non-blocking) ----
+    def _ctrl_messages_ProgressUpdate(self, frame, name, node, in_port):
+        self._log(frame.depth, f"     progress {self._pull(frame, node.get('value'))}%")
+        self._fire(frame, node.get("done"))
+
+    def _ctrl_messages_StatusUpdate(self, frame, name, node, in_port):
+        self._log(frame.depth, f"     status: {self._pull(frame, node.get('status'))!r}")
+        self._fire(frame, node.get("done"))
+
+    def _ctrl_messages_Listen(self, frame, name, node, in_port):
+        # No ODIN message framework on a bench -> treat the awaited message as
+        # received (fire done), non-blocking; fall back to timed_out if there's
+        # no done port.
+        self._fire(frame, node.get("done") or node.get("timed_out"))
+
+    def _ctrl_messages_Send(self, frame, name, node, in_port):
+        # Publish to the ODIN manufacturing-message bus (e.g. a brake-dyno controller).
+        # No such bus on a bench -> fire-and-forget; continue via `done` when present
+        # (some Send nodes are terminal, with the reply arriving via a later Listen).
+        self._log(frame.depth, f"     msg.send {self._pull(frame, node.get('payload'))!r}")
+        self._fire(frame, node.get("done"))
+
+    # ---- proto.ReadFile (served from the firmware dump via CidFilesystem) ----
+    def _ctrl_proto_ReadFile(self, frame, name, node, in_port):
+        frame.scratch[name] = self.backend.cid_read_file(
+            self._pull(frame, node.get("filepath")),
+            self._pull(frame, node.get("mode")) or "r")
+        self._fire(frame, node.get("done"))
+
+    # ---- can.CANSignalMonitor (fire value_changed on a change; else timed_out) ----
+    def _ctrl_can_CANSignalMonitor(self, frame, name, node, in_port):
+        if node.get("enabled") is not None and not self._pull(frame, node["enabled"]):
+            return self._fire(frame, node.get("done") or node.get("value_changed"))
+        sig = self._pull(frame, node.get("signal_name"))
+        bus = self._pull(frame, node.get("bus_name"))
+        timeout = self._pull(frame, node.get("timeout")) or 10
+        deadline = time.monotonic() + timeout * (self._time_scale or 0.0)
+        initial = self.backend.can_read(sig, bus)
+        frame.scratch[name] = {"current": initial}
+        first = True
+        while first or time.monotonic() < deadline:
+            first = False
+            v = self.backend.can_read(sig, bus)
+            frame.scratch[name] = {"current": v}
+            if v is not None and v != initial:
+                return self._fire(frame, node.get("value_changed"))
+            if frame.cancel.is_set():
+                break
+            self._sleep(0.05)
+        self._fire(frame, node.get("timed_out") or node.get("done"))
+
+    def _ctrl_can_CANSignalValueComparison(self, frame, name, node, in_port):
+        sig = self._pull(frame, node["signal_name"])
+        bus = self._pull(frame, node.get("bus_name"))
+        target = self._pull(frame, node["target"])
+        comp = self._pull(frame, node["comparator"])
+        timeout = self._pull(frame, node.get("timeout")) or 10
+        deadline = time.monotonic() + timeout * (self._time_scale or 0.0)
+        v = None
+        first = True
+        while first or time.monotonic() < deadline:
+            first = False
+            v = self.backend.can_read(sig, bus)
+            if self._cmp(comp, v, target):
+                self._log(frame.depth, f"     can {sig}={v} (cmp {comp} {target}) -> true")
+                return self._fire(frame, node.get("true"))
+            if frame.cancel.is_set():
+                break
+            self._sleep(0.05)
+        self._log(frame.depth, f"     can {sig}={v} (cmp {comp} {target}) -> false")
+        self._fire(frame, node.get("false"))
+
+    def _ctrl_uds_UdsTesterPresent(self, frame, name, node, in_port):
+        self.backend.uds(self._pull(frame, node["node_name"])).tester_present()
+        self._fire(frame, node.get("done"))
+
+    def _ctrl_uds_UdsDiagnosticSession(self, frame, name, node, in_port):
+        nn = self._pull(frame, node["node_name"])
+        self.backend.uds(nn).diagnostic_session(self._pull(frame, node.get("session_type")))
+        self._fire(frame, node.get("done"))
+
+    def _ctrl_uds_UdsRoutineControl(self, frame, name, node, in_port):
+        nn = self._pull(frame, node["node_name"])
+        self.backend.uds(nn).routine_control(
+            self._pull(frame, node.get("routine_id")),
+            self._pull(frame, node.get("input_payload")),
+            self._pull(frame, node.get("routine_type")))
+        self._fire(frame, node.get("done"))
+
+    def _ctrl_odx_OdxStartAndWaitResults(self, frame, name, node, in_port):
+        nn = self._pull(frame, node["node_name"])
+        routine = self._pull(frame, node["routine_name"])
+        results = self.backend.odx(nn).start_and_wait(
+            routine,
+            self._pull(frame, node.get("status_parameter")),
+            self._pull(frame, node.get("in_progress_statuses")) or [True],
+            self._pull(frame, node.get("timeout")) or 1,
+            input_parameters=self._pull(frame, node.get("input_parameters")),
+            stop_routine=self._pull(frame, node.get("stop_routine")) or False,
+            cancel=frame.cancel, time_scale=self._time_scale)
+        frame.scratch.setdefault(name, {})["results"] = results
+        self._log(frame.depth, f"     odx {routine}@{nn} -> {results}")
+        self._fire(frame, node.get("done"))
+
+    def _ctrl_odx_OdxStartAndWaitResults_V2(self, frame, name, node, in_port):
+        # V2: takes an explicit diagnostic_session, max_runtime (seconds) and
+        # success/failed control ports. Poll like the V1 node; the routine leaving
+        # its in-progress set before the deadline is treated as success, a timeout
+        # (or error) as failure. (The exact pass/fail status set isn't in the graph;
+        # confirm on the bench for a routine whose terminal status can be "failed".)
+        nn = self._pull(frame, node["node_name"])
+        routine = self._pull(frame, node["routine_name"])
+        status_param = self._pull(frame, node.get("status_parameter"))
+        in_prog = self._pull(frame, node.get("in_progress_statuses")) or [True]
+        sess = self._pull(frame, node.get("diagnostic_session"))
+        ok = True
+        try:
+            if sess:
+                self.backend.odx(nn)  # session is applied by the adapter as needed
+            results = self.backend.odx(nn).start_and_wait(
+                routine, status_param, in_prog,
+                self._pull(frame, node.get("max_runtime")) or 1,
+                stop_routine=self._pull(frame, node.get("should_stop")) or False,
+                cancel=frame.cancel, time_scale=self._time_scale)
+            final = results.get(status_param) if status_param else None
+            ok = final not in in_prog  # left the in-progress set -> completed
+        except Exception as e:  # noqa: BLE001  (a routine/transport error is a fail)
+            results, ok = {"error": str(e)}, False
+        frame.scratch.setdefault(name, {})["results"] = results
+        self._log(frame.depth, f"     odx-v2 {routine}@{nn} ok={ok} -> {results}")
+        self._fire(frame, node.get("success") if ok else node.get("failed"))
+
+    def _data_odx_OdxStartAndWaitResults_V2(self, frame, name, node, port):
+        if port == "results_control_type":
+            return "REQUEST_ROUTINE_RESULTS"
+        return frame.scratch.get(name, {}).get("results", {})
+
+    # ---- odx.* routines/DIDs (named params via the ODJ codec) ----
+    def _ctrl_odx_OdxStartRoutine(self, frame, name, node, in_port):
+        nn = self._pull(frame, node["node_name"])
+        self.backend.odx(nn).start_routine(
+            self._pull(frame, node["routine_name"]),
+            self._pull(frame, node.get("params")))
+        self._fire(frame, node.get("done"))
+
+    def _ctrl_odx_OdxStopRoutine(self, frame, name, node, in_port):
+        nn = self._pull(frame, node["node_name"])
+        self.backend.odx(nn).stop_routine(
+            self._pull(frame, node["routine_name"]),
+            self._pull(frame, node.get("params")))
+        self._fire(frame, node.get("done"))
+
+    def _ctrl_odx_OdxRequestResults(self, frame, name, node, in_port):
+        nn = self._pull(frame, node["node_name"])
+        results = self.backend.odx(nn).request_results(
+            self._pull(frame, node["routine_name"]),
+            self._pull(frame, node.get("params")))
+        frame.scratch.setdefault(name, {})["results"] = results
+        self._fire(frame, node.get("done"))
+
+    def _ctrl_odx_OdxReadData(self, frame, name, node, in_port):
+        nn = self._pull(frame, node["node_name"])
+        data = self.backend.odx(nn).read_data(self._pull(frame, node["data_name"]))
+        frame.scratch.setdefault(name, {})["data"] = data
+        self._fire(frame, node.get("done"))
+
+    def _ctrl_odx_OdxWriteData(self, frame, name, node, in_port):
+        nn = self._pull(frame, node["node_name"])
+        self.backend.odx(nn).write_data(
+            self._pull(frame, node["data_name"]),
+            self._pull(frame, node.get("data")))
+        self._fire(frame, node.get("done"))
+
+    def _odx_get_value(self, frame, node, parsed):
+        nn = self._pull(frame, node["node_name"])
+        return self.backend.odx(nn).get_value(
+            self._pull(frame, node.get("routine_name")),
+            self._pull(frame, node.get("param_name")),
+            self._pull(frame, node.get("param_value")),
+            parsed)
+
+    def _ctrl_odx_OdxGetParsedValue(self, frame, name, node, in_port):
+        frame.scratch[name] = self._odx_get_value(frame, node, parsed=True)
+        self._fire(frame, node.get("done"))
+
+    def _ctrl_odx_OdxGetRawValue(self, frame, name, node, in_port):
+        frame.scratch[name] = self._odx_get_value(frame, node, parsed=False)
+        self._fire(frame, node.get("done"))
+
+    # ---- uds.* raw services ----
+    def _ctrl_uds_UdsReadData(self, frame, name, node, in_port):
+        nn = self._pull(frame, node["node_name"])
+        data = self.backend.uds(nn).read_data(self._pull(frame, node["data_id"]))
+        frame.scratch.setdefault(name, {})["data"] = data
+        self._fire(frame, node.get("done"))
+
+    def _ctrl_uds_UdsWriteData(self, frame, name, node, in_port):
+        nn = self._pull(frame, node["node_name"])
+        self.backend.uds(nn).write_data(
+            self._pull(frame, node["data_id"]),
+            self._pull(frame, node.get("input_payload")))
+        self._fire(frame, node.get("done"))
+
+    def _ctrl_uds_UdsSecurityAccess(self, frame, name, node, in_port):
+        nn = self._pull(frame, node["node_name"])
+        self.backend.uds(nn).security_access(self._pull(frame, node.get("security_level")))
+        self._fire(frame, node.get("done"))
+
+    def _ctrl_uds_UdsIOControl(self, frame, name, node, in_port):
+        # InputOutputControlByIdentifier (0x2F): control_id=DID, control_type=IOCBI
+        # controlParameter name, input_payload=controlState bytes.
+        nn = self._pull(frame, node["node_name"])
+        data = self.backend.uds(nn).io_control(
+            self._pull(frame, node.get("control_id")),
+            self._pull(frame, node.get("control_type")),
+            self._pull(frame, node.get("input_payload")))
+        frame.scratch.setdefault(name, {})["data"] = data
+        self._fire(frame, node.get("done"))
+
+    def _data_uds_UdsIOControl(self, frame, name, node, port):
+        return frame.scratch.get(name, {}).get("data", b"")
+
+    # ---- isotp.* raw transport (explicit tx/rx CAN IDs, not a UDS service) ----
+    def _ctrl_isotp_Send(self, frame, name, node, in_port):
+        ok = self.backend.isotp_send(
+            _to_int(self._pull(frame, node.get("to_controller"))),
+            _to_int(self._pull(frame, node.get("from_controller"))),
+            self._pull(frame, node.get("data")),
+            bus=self._pull(frame, node.get("bus_name")))
+        frame.scratch[name] = {"success": bool(ok)}
+        self._fire(frame, node.get("done"))
+
+    def _data_isotp_Send(self, frame, name, node, port):
+        return frame.scratch.get(name, {}).get("success", True)
+
+    def _ctrl_uds_UdsEcuReset(self, frame, name, node, in_port):
+        nn = self._pull(frame, node["node_name"])
+        self.backend.uds(nn).ecu_reset(
+            self._pull(frame, node.get("reset_type")),
+            self._pull(frame, node.get("response_required")))
+        self._fire(frame, node.get("done"))
+
+    def _ctrl_uds_UdsClearDtcs(self, frame, name, node, in_port):
+        nn = self._pull(frame, node["node_name"])
+        self.backend.uds(nn).clear_dtcs(self._pull(frame, node.get("dtc_mask")))
+        self._fire(frame, node.get("done"))
+
+    def _ctrl_uds_UdsReadDtcs(self, frame, name, node, in_port):
+        nn = self._pull(frame, node["node_name"])
+        dtcs = self.backend.uds(nn).read_dtcs(self._pull(frame, node.get("dtc_mask")))
+        # `dtcs` is a {dtc_code: status} dict so dicts.Keys / control.ForEachEntry
+        # (the graph's downstream consumers) work; empty on a healthy ECU.
+        frame.scratch[name] = {"dtcs": dtcs}
+        self._fire(frame, node.get("done"))
+
+    def _ctrl_uds_UdsTesterPresentContext(self, frame, name, node, in_port):
+        # UdsSession keeps its own TesterPresent thread alive; just run the body.
+        self.backend.uds(self._pull(frame, node["node_name"])).tester_present()
+        self._fire(frame, node.get("body"))
+        self._fire(frame, node.get("done"))
+
+    # ---------------- data handlers ----------------
+    def _data_networks_Input(self, frame, name, node, port):
+        # A caller that binds this input to None means "unset" -> fall back to the
+        # Input node's declared default (ODIN semantics; e.g. WRITE_DRIVE_TYPE's
+        # pmr_power_ecu default 'VCLEFT' when the task passes None). Only a non-None
+        # bound value overrides the default.
+        v = frame.inputs.get(name)
+        if v is not None:
+            return v
+        return self._pull(frame, node.get("default"))
+
+    def _data_networks_Get(self, frame, name, node, port):
+        var = self._pull(frame, node["variable"])
+        if var in frame.vars:
+            return frame.vars[var]
+        return self._pull(frame, node.get("default"))
+
+    def _data_constant_Constant(self, frame, name, node, port):
+        return self._pull(frame, node.get("value"))
+
+    def _data_logic_Compare(self, frame, name, node, port):
+        # Compare carries an `operator` (0:== 1:!= 2:< 3:<= 4:> 5:>=); default ==.
+        return self._cmp(self._pull(frame, node.get("operator")),
+                         self._pull(frame, node["a"]), self._pull(frame, node["b"]))
+
+    def _data_collections_GetItem(self, frame, name, node, port):
+        data = self._pull(frame, node["data"])
+        key = self._pull(frame, node["key"])
+        default = self._pull(frame, node.get("default"))
+        if isinstance(data, dict):
+            return data.get(key, default)
+        if isinstance(data, (list, tuple, str)):
+            try:
+                return data[key]
+            except (IndexError, KeyError, TypeError):
+                return default
+        return default
+
+    _data_dicts_GetItem = _data_collections_GetItem
+
+    def _data_reporting_BoolToResultCode(self, frame, name, node, port):
+        return 0 if self._pull(frame, node["input"]) else 1
+
+    def _data_strings_Concat(self, frame, name, node, port):
+        return str(self._pull(frame, node["a"])) + str(self._pull(frame, node["b"]))
+
+    def _data_cid_GetDataValue(self, frame, name, node, port):
+        return self.backend.cid_get(self._pull(frame, node["data_name"]))
+
+    def _data_cid_ListDataValues(self, frame, name, node, port):
+        return self.backend.cid_list_values(self._pull(frame, node.get("dv")))
+
+    def _data_cid_LoadData(self, frame, name, node, port):
+        return self.backend.cid_load(self._pull(frame, node.get("filename")))
+
+    def _data_cid_HashFile(self, frame, name, node, port):
+        return self.backend.cid_hash_file(
+            self._pull(frame, node.get("filepath")),
+            self._pull(frame, node.get("algorithm")) or "sha256")
+
+    def _data_cid_GetVin(self, frame, name, node, port):
+        return self.backend.cid_vin(bool(self._pull(frame, node.get("in_hex"))))
+
+    def _data_cid_GetVitals(self, frame, name, node, port):
+        return self.backend.cid_vitals()
+
+    def _data_cid_GetDirectoryContents(self, frame, name, node, port):
+        return frame.scratch.get(name, {}).get(port or "result")
+
+    def _data_cid_Grep(self, frame, name, node, port):
+        res = frame.scratch.get(name, {})
+        return res.get(port, res.get("stdout", ""))
+
+    def _data_cid_GetDiskFree(self, frame, name, node, port):
+        return frame.scratch.get(name, 0)
+
+    def _data_cid_ExecuteApplication(self, frame, name, node, port):
+        res = frame.scratch.get(name, {})
+        return res.get(port, res)
+
+    _data_cid_ExecuteScript = _data_cid_ExecuteApplication
+    _data_cid_CidCommand = _data_cid_ExecuteApplication
+
+    # ---- Step 6: cheap-logic + live-CAN data handlers ----
+    def _data_dicts_FromInputs(self, frame, name, node, port):
+        # Gather the single-letter input ports (a, b, c, ...) into a list, ordered
+        # by letter. (Best-guess: the `out` port is a positional collection; the
+        # only ambiguous case is all-dict inputs, which a merge would also fit.)
+        keys = sorted(k for k in node if len(k) == 1 and k.isalpha())
+        return [self._pull(frame, node[k]) for k in keys]
+
+    def _data_bytes_Base64Decode(self, frame, name, node, port):
+        v = self._pull(frame, node["value"])
+        return base64.b64decode(v) if v is not None else b""
+
+    def _data_bytes_Base64Encode(self, frame, name, node, port):
+        return base64.b64encode(self._as_bytes(self._pull(frame, node["value"])))
+
+    def _data_bytes_RandomBytes(self, frame, name, node, port):
+        return os.urandom(int(self._pull(frame, node.get("n")) or 0))
+
+    def _data_can_CANSignalRead(self, frame, name, node, port):
+        return self.backend.can_read(self._pull(frame, node.get("signal_name")),
+                                     self._pull(frame, node.get("bus_name")))
+
+    def _data_can_CANSignalMonitor(self, frame, name, node, port):
+        return frame.scratch.get(name, {}).get(port or "current")
+
+    def _data_can_ActiveAlerts(self, frame, name, node, port):
+        return self.backend.can_active_alerts(
+            self._pull(frame, node.get("bus_name")),
+            self._pull(frame, node.get("prefix")),
+            self._pull(frame, node.get("audience")))
+
+    def _data_can_BytesToInt(self, frame, name, node, port):
+        b = self._pull(frame, node.get("bytes"))
+        if isinstance(b, (bytes, bytearray)):
+            return int.from_bytes(b, "big")
+        if isinstance(b, str):
+            return int.from_bytes(bytes.fromhex(b), "big") if b else 0
+        return b  # already an int (e.g. from GetChunkFromBytes)
+
+    def _data_proto_ReadFile(self, frame, name, node, port):
+        return frame.scratch.get(name)
+
+    def _data_odx_OdxStartAndWaitResults(self, frame, name, node, port):
+        if port == "results_control_type":
+            return "REQUEST_ROUTINE_RESULTS"
+        return frame.scratch.get(name, {}).get("results", {})
+
+    def _data_odx_OdxRequestResults(self, frame, name, node, port):
+        return frame.scratch.get(name, {}).get("results", {})
+
+    def _data_odx_OdxReadData(self, frame, name, node, port):
+        return frame.scratch.get(name, {}).get("data", {})
+
+    def _data_odx_OdxGetParsedValue(self, frame, name, node, port):
+        return frame.scratch.get(name)
+
+    def _data_odx_OdxGetRawValue(self, frame, name, node, port):
+        return frame.scratch.get(name)
+
+    def _data_uds_UdsReadData(self, frame, name, node, port):
+        return frame.scratch.get(name, {}).get("data", b"")
+
+    def _data_uds_UdsReadDtcs(self, frame, name, node, port):
+        return frame.scratch.get(name, {}).get("dtcs", {})
+
+    def _data_uds_UdsDTCMaskRepr(self, frame, name, node, port):
+        # Render a DTC status-mask byte as a hex string (cosmetic; used in reports).
+        v = self._pull(frame, node.get("dtc_mask_value"))
+        return f"0x{int(v):02X}" if isinstance(v, int) else str(v)
+
+    def _data_control_TryExceptAll(self, frame, name, node, port):
+        return frame.scratch.get(name, {}).get("exception")
+
+    # ================= Step 2: pure-logic + iteration handler batch =================
+    # Data nodes return one value (the `port` arg is ignored unless a node exposes
+    # several named outputs -- the iteration nodes below use it). Field/port names were
+    # read out of the bundle (the inspection recipe), not guessed.
+
+    # ---- logic ----
+    def _data_logic_IsIn(self, frame, name, node, port):
+        b = self._pull(frame, node["b"])
+        return self._pull(frame, node["a"]) in b if b is not None else False
+
+    def _data_logic_IsNotIn(self, frame, name, node, port):
+        b = self._pull(frame, node["b"])
+        return self._pull(frame, node["a"]) not in b if b is not None else True
+
+    def _data_logic_IsEmpty(self, frame, name, node, port):
+        a = self._pull(frame, node["a"])
+        if a is None:
+            return True
+        try:
+            return len(a) == 0
+        except TypeError:
+            return not a
+
+    def _data_logic_Or(self, frame, name, node, port):
+        return self._pull(frame, node["a"]) or self._pull(frame, node["b"])
+
+    def _data_logic_And(self, frame, name, node, port):
+        return self._pull(frame, node["a"]) and self._pull(frame, node["b"])
+
+    def _data_logic_Not(self, frame, name, node, port):
+        return not self._pull(frame, node["a"])
+
+    def _data_logic_IsNone(self, frame, name, node, port):
+        return self._pull(frame, node["a"]) is None
+
+    def _data_logic_IsNonZero(self, frame, name, node, port):
+        return bool(self._pull(frame, node["a"]))
+
+    def _data_logic_Between(self, frame, name, node, port):
+        a = self._pull(frame, node["a"])
+        lo = self._pull(frame, node["low"])
+        hi = self._pull(frame, node["high"])
+        return lo <= a <= hi if None not in (a, lo, hi) else False
+
+    def _data_logic_LessThan(self, frame, name, node, port):
+        return self._cmp(2, self._pull(frame, node["a"]), self._pull(frame, node["b"]))
+
+    def _data_logic_MultiAndOr(self, frame, name, node, port):
+        op = self._pull(frame, node.get("operator"))
+        vals = [self._pull(frame, v) for v in (node.get("inputs") or {}).values()]
+        return all(vals) if op == "and" else any(vals)
+
+    # ---- dicts (immutable: return a new dict) ----
+    def _data_dicts_SetItem(self, frame, name, node, port):
+        data = self._pull(frame, node.get("data"))
+        out = dict(data) if isinstance(data, dict) else {}
+        out[self._pull(frame, node["key"])] = self._pull(frame, node["value"])
+        return out
+
+    def _data_dicts_Keys(self, frame, name, node, port):
+        data = self._pull(frame, node["data"])
+        return list(data.keys()) if isinstance(data, dict) else []
+
+    def _data_dicts_Values(self, frame, name, node, port):
+        data = self._pull(frame, node["data"])
+        return list(data.values()) if isinstance(data, dict) else []
+
+    def _data_dicts_Merge(self, frame, name, node, port):
+        return {**(self._pull(frame, node["a"]) or {}),
+                **(self._pull(frame, node["b"]) or {})}
+
+    def _data_dicts_HasKey(self, frame, name, node, port):
+        data = self._pull(frame, node["data"])
+        return isinstance(data, dict) and self._pull(frame, node["key"]) in data
+
+    # ---- collections / lists ----
+    def _data_collections_Len(self, frame, name, node, port):
+        data = self._pull(frame, node["data"])
+        return len(data) if data is not None else 0
+
+    def _data_collections_Sort(self, frame, name, node, port):
+        return sorted(self._pull(frame, node["data"]) or [])
+
+    def _data_lists_Append(self, frame, name, node, port):
+        out = list(self._pull(frame, node.get("items")) or [])
+        out.append(self._pull(frame, node["value"]))
+        return out
+
+    def _data_lists_Extend(self, frame, name, node, port):
+        return [*(self._pull(frame, node["a"]) or []),
+                *(self._pull(frame, node["b"]) or [])]
+
+    def _data_lists_Any(self, frame, name, node, port):
+        return any(self._pull(frame, node["items"]) or [])
+
+    def _data_lists_Splice(self, frame, name, node, port):
+        items = self._pull(frame, node["items"]) or []
+        start = self._pull(frame, node.get("start")) or 0
+        return items[start:self._pull(frame, node.get("end"))]
+
+    # ---- math ----
+    def _data_math_Add(self, frame, name, node, port):
+        return self._pull(frame, node["a"]) + self._pull(frame, node["b"])
+
+    def _data_math_Subtract(self, frame, name, node, port):
+        return self._pull(frame, node["a"]) - self._pull(frame, node["b"])
+
+    def _data_math_Multiply(self, frame, name, node, port):
+        return self._pull(frame, node["a"]) * self._pull(frame, node["b"])
+
+    def _data_math_Divide(self, frame, name, node, port):
+        return self._pull(frame, node["a"]) / self._pull(frame, node["b"])
+
+    def _data_math_Mod(self, frame, name, node, port):
+        return self._pull(frame, node["x"]) % self._pull(frame, node["divisor"])
+
+    def _data_math_SeriesSum(self, frame, name, node, port):
+        return sum(self._pull(frame, node.get("series")) or [])
+
+    def _data_math_Abs(self, frame, name, node, port):
+        return abs(self._pull(frame, node["value"]))
+
+    # ---- strings ----
+    def _data_strings_Format(self, frame, name, node, port):
+        text = self._pull(frame, node["text"]) or ""
+        opts = self._pull(frame, node.get("options"))
+        return text.format(**opts) if isinstance(opts, dict) else text
+
+    def _data_strings_Split(self, frame, name, node, port):
+        return str(self._pull(frame, node["text"])).split(
+            self._pull(frame, node.get("separator")))
+
+    def _data_strings_Join(self, frame, name, node, port):
+        joiner = self._pull(frame, node.get("joiner")) or ""
+        return joiner.join(str(x) for x in (self._pull(frame, node["items"]) or []))
+
+    def _data_strings_Substring(self, frame, name, node, port):
+        s = str(self._pull(frame, node["string"]))
+        start = self._pull(frame, node.get("start")) or 0
+        return s[start:self._pull(frame, node.get("end"))]
+
+    def _data_strings_Rstrip(self, frame, name, node, port):
+        return str(self._pull(frame, node["str"])).rstrip()
+
+    def _data_strings_Strip(self, frame, name, node, port):
+        return str(self._pull(frame, node["str"])).strip()
+
+    def _data_strings_Splitlines(self, frame, name, node, port):
+        return str(self._pull(frame, node["text"])).splitlines()
+
+    def _data_strings_Case(self, frame, name, node, port):
+        # case enum best-guess 0:lower 1:upper 2:title 3:capitalize (confirm on bench).
+        text = str(self._pull(frame, node["text"]))
+        case = int(self._pull(frame, node.get("case")) or 0)
+        funcs = [text.lower, text.upper, text.title, text.capitalize]
+        return funcs[case]() if 0 <= case < len(funcs) else text
+
+    # ---- control: data ternary + iteration + misc ----
+    def _data_control_Switch(self, frame, name, node, port):
+        branch = "if_true" if self._pull(frame, node["expr"]) else "if_false"
+        return self._pull(frame, node.get(branch))
+
+    def _ctrl_control_ForEach(self, frame, name, node, in_port):
+        for item in self._pull(frame, node.get("items")) or []:
+            if frame.cancel.is_set():
+                break
+            frame.scratch[name] = {"item": item}
+            if self._run_body(frame, node.get("run_each")):
+                break
+        self._fire(frame, node.get("done"))
+
+    def _data_control_ForEach(self, frame, name, node, port):
+        return frame.scratch.get(name, {}).get(port or "item")
+
+    def _ctrl_control_ForEachEntry(self, frame, name, node, in_port):
+        data = self._pull(frame, node.get("data"))
+        for key, value in (data.items() if isinstance(data, dict) else []):
+            if frame.cancel.is_set():
+                break
+            frame.scratch[name] = {"key": key, "value": value}
+            if self._run_body(frame, node.get("run_each")):
+                break
+        self._fire(frame, node.get("done"))
+
+    def _data_control_ForEachEntry(self, frame, name, node, port):
+        return frame.scratch.get(name, {}).get(port)
+
+    def _ctrl_control_ForLoop(self, frame, name, node, in_port):
+        start = int(self._pull(frame, node.get("start")) or 0)
+        end = int(self._pull(frame, node.get("end")) or 0)
+        for i in range(start, end):
+            if frame.cancel.is_set():
+                break
+            frame.scratch[name] = {"i": i}
+            if self._run_body(frame, node.get("run_each")):
+                break
+        self._fire(frame, node.get("done"))
+
+    def _data_control_ForLoop(self, frame, name, node, port):
+        return frame.scratch.get(name, {}).get(port or "i")
+
+    def _ctrl_control_TimeoutLoop(self, frame, name, node, in_port):
+        timeout = self._pull(frame, node.get("timeout")) or 0
+        poll = self._pull(frame, node.get("sleep")) or 0
+        deadline = time.monotonic() + (timeout / 1000.0) * (self._time_scale or 0.0)
+        first = True
+        while first or time.monotonic() < deadline:
+            first = False
+            if self._run_body(frame, node.get("run_body")):
+                break
+            if "condition" in node and self._pull(frame, node["condition"]):
+                self._fire(frame, node.get("passed") or node.get("done"))
+                return
+            if frame.cancel.is_set():
+                break
+            self._sleep(poll / 1000.0)
+        self._fire(frame, node.get("timed_out") or node.get("done"))
+
+    def _ctrl_control_Delay(self, frame, name, node, in_port):
+        self._sleep(self._pull(frame, node.get("seconds")) or 0)
+        self._fire(frame, node.get("done"))
+
+    def _ctrl_control_Either(self, frame, name, node, in_port):
+        self._fire(frame, node.get("done"))
+
+    def _ctrl_control_Sync(self, frame, name, node, in_port):
+        self._fire(frame, node.get("done"))
+
+    def _ctrl_control_Counter(self, frame, name, node, in_port):
+        frame.scratch[name] = frame.scratch.get(name, 0) + 1
+        self._fire(frame, node.get("updated"))
+
+    def _data_control_Counter(self, frame, name, node, port):
+        return frame.scratch.get(name, 0)
+
+    def _ctrl_control_Case(self, frame, name, node, in_port):
+        sel = self._pull(frame, node.get("selector"))
+        runs = node.get("run_cases") or {}
+        for cname, cval in (node.get("cases") or {}).items():
+            if self._pull(frame, cval) == sel:
+                self._fire(frame, runs.get(cname))
+                return
+        self._fire(frame, node.get("default") or runs.get("default"))
+
+    # -- fan-out / join. MultiSplit fires each named branch (index order); each branch
+    # eventually fires MultiMerge.dependencies.<branch>. MultiMerge counts arrivals and
+    # fires `done` once every dependency has arrived. Sequential execution is correct
+    # here: the branches converge at the merge before the graph continues.
+    def _ctrl_control_MultiSplit(self, frame, name, node, in_port):
+        branches = node.get("branches") or {}
+        for _bn, fld in sorted(
+                branches.items(),
+                key=lambda kv: kv[1].get("index", 0) if isinstance(kv[1], dict) else 0):
+            self._fire(frame, fld)
+
+    def _ctrl_control_MultiMerge(self, frame, name, node, in_port):
+        deps = node.get("dependencies") or {}
+        arrived = frame.scratch.setdefault(name, set())
+        arrived.add(in_port.split(".", 1)[1] if in_port.startswith("dependencies.")
+                    else in_port)
+        if arrived.issuperset(deps.keys()):
+            self._fire(frame, node.get("done"))
+
+    def _ctrl_control_Merge(self, frame, name, node, in_port):
+        # OR-join: whichever incoming branch (`first`/`second`) arrives continues via
+        # `done`. In practice the branches are mutually exclusive (if/else convergence).
+        self._fire(frame, node.get("done"))
+
+    # -- control.ForAccumulate: fired once per enclosing-loop iteration; appends the
+    # pulled `value` to an accumulator read back (post-loop) via its `results` port.
+    def _ctrl_control_ForAccumulate(self, frame, name, node, in_port):
+        frame.scratch.setdefault(name, []).append(self._pull(frame, node.get("value")))
+        self._fire(frame, node.get("done"))  # usually absent -> terminal accumulate
+
+    def _data_control_ForAccumulate(self, frame, name, node, port):
+        return frame.scratch.get(name, [])
+
+    # ---- bytes ----
+    @staticmethod
+    def _as_bytes(v):
+        if v is None:
+            return b""
+        if isinstance(v, bytes):
+            return v
+        if isinstance(v, (bytearray, list)):
+            return bytes(v)
+        if isinstance(v, str):
+            return bytes.fromhex(v)
+        raise TypeError(f"cannot coerce {type(v).__name__} to bytes")
+
+    def _ctrl_bytes_AppendBytes(self, frame, name, node, in_port):
+        base = self._as_bytes(self._pull(frame, node.get("input_bytes")))
+        add = self._as_bytes(self._pull(frame, node.get("append_bytes")))
+        frame.scratch[name] = base + add
+        self._fire(frame, node.get("done"))
+
+    def _data_bytes_AppendBytes(self, frame, name, node, port):
+        return frame.scratch.get(name, b"")
+
+    def _ctrl_bytes_GetChunkFromBytes(self, frame, name, node, in_port):
+        data = self._as_bytes(self._pull(frame, node.get("input_bytes")))
+        byte0 = int(self._pull(frame, node.get("byte_start_position")) or 0)
+        bit0 = int(self._pull(frame, node.get("bit_start_position")) or 0)
+        blen = int(self._pull(frame, node.get("bit_length")) or 0)
+        # MSB-first big-endian bit extraction (endianness field is rare; big default --
+        # confirm little-endian handling on the bench before trusting non-byte-aligned).
+        val = 0
+        for i in range(blen):
+            ab = bit0 + i
+            bi = byte0 + ab // 8
+            bit = ((data[bi] >> (7 - ab % 8)) & 1) if bi < len(data) else 0
+            val = (val << 1) | bit
+        frame.scratch[name] = val
+        self._fire(frame, node.get("done"))
+
+    def _data_bytes_GetChunkFromBytes(self, frame, name, node, port):
+        return frame.scratch.get(name, 0)
+
+    def _data_bytes_EncodeToBytes(self, frame, name, node, port):
+        return str(self._pull(frame, node["utf8_chars"])).encode("utf-8")
+
+    def _data_bytes_DecodeToString(self, frame, name, node, port):
+        return self._as_bytes(self._pull(frame, node["value"])).decode("utf-8", "replace")
+
+    # ---- json / regex / sets / misc / types ----
+    def _data_json_Dumps(self, frame, name, node, port):
+        return json.dumps(self._pull(frame, node["json"]))
+
+    def _data_json_Loads(self, frame, name, node, port):
+        return json.loads(self._pull(frame, node["string"]))
+
+    def _data_regex_Findall(self, frame, name, node, port):
+        data = self._pull(frame, node["data"])
+        return re.findall(self._pull(frame, node["pattern"]),
+                          data if data is not None else "")
+
+    def _data_sets_Intersection(self, frame, name, node, port):
+        a = set(self._pull(frame, node["a"]) or [])
+        return list(a & set(self._pull(frame, node["b"]) or []))
+
+    def _data_sets_Difference(self, frame, name, node, port):
+        a = set(self._pull(frame, node["a"]) or [])
+        return list(a - set(self._pull(frame, node["b"]) or []))
+
+    def _data_misc_SanitizeString(self, frame, name, node, port):
+        allowed: set = set()
+        if self._pull(frame, node.get("digits")):
+            allowed |= set(string.digits)
+        if self._pull(frame, node.get("ascii_letters")):
+            allowed |= set(string.ascii_letters)
+        if self._pull(frame, node.get("whitespace")):
+            allowed |= set(string.whitespace)
+        extra = self._pull(frame, node.get("allowed_chars"))
+        if extra:
+            allowed |= set(extra)
+        text = str(self._pull(frame, node.get("input_text")) or "")
+        if all(c in allowed for c in text):
+            return text
+        raise ValueError(
+            self._pull(frame, node.get("value_error_message")) or "invalid string")
+
+    def _data_types_VariantToNumber(self, frame, name, node, port):
+        v = self._pull(frame, node["value"])
+        try:
+            return int(v)
+        except (TypeError, ValueError):
+            return float(v)
+
+    def _data_misc_DateTime(self, frame, name, node, port):
+        # Output port `now`: an ISO-8601 timestamp string (downstream consumers
+        # format/concatenate it into reports).
+        return datetime.datetime.now().isoformat()
+
+    def _data_misc_Uuid(self, frame, name, node, port):
+        return str(uuid.uuid4())
+
+
+# =====================================================================================
+def _print_proc_table(procs) -> None:
+    """Human-readable --list output: a runnable flag, name, title, valid_states."""
+    n_runnable = sum(1 for x in procs if x["runnable"])
+    print(f"procedures: {len(procs)}  runnable-now: {n_runnable}")
+    for x in procs:
+        flag = "OK" if x["runnable"] else "--"
+        title = x["title"] or ""
+        line = f"  [{flag}] {x['name']:<44} {title}"
+        if x["valid_states"]:
+            line += f"  <{'|'.join(x['valid_states'])}>"
+        print(line)
+        if not x["runnable"] and x["missing_types"]:
+            print(f"         missing: {', '.join(x['missing_types'])}")
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--bundle", type=Path, default=None,
+                   help="bundle networks/ dir (default: config.ODIN_BUNDLE from "
+                        "TM3_ROOT / TM3_ODIN_BUNDLE in .env)")
+    p.add_argument("--procedure", default=DEFAULT_PROC,
+                   help=f"graph basename to run (default {DEFAULT_PROC})")
+    p.add_argument("--backend", choices=["mock", "bench"], default="mock")
+    p.add_argument("--scenario", default="success",
+                   choices=["success", "not-dyno", "speed-fail", "learn-fail"],
+                   help="(mock) which choreography to script")
+    p.add_argument("--channel", default=None, help="(bench) CAN channel (default: TM3_VEHICLE_CHANNEL)")
+    p.add_argument("--interface", default=None,
+                   help="(bench) python-can interface (default: TM3_INTERFACE)")
+    p.add_argument("--list", action="store_true",
+                   help="list entry procedures (with runnable status) instead of running one")
+    p.add_argument("--runnable", action="store_true",
+                   help="(with --list) list only procedures runnable now")
+    p.add_argument("--json", action="store_true", help="emit machine-readable JSON")
+    p.add_argument("-v", "--verbose", action="store_true", help="print the node execution trace")
+
+    import config as _cfg
+    _cfg.apply_defaults(p)  # channel/interface from .env (TM3_VEHICLE_CHANNEL/TM3_INTERFACE)
+    args = p.parse_args()
+
+    import odin_service
+
+    bundle = args.bundle or _cfg.ODIN_BUNDLE
+    if bundle is None:
+        p.error("no bundle: pass --bundle or set TM3_ROOT (or TM3_ODIN_BUNDLE) in .env")
+
+    if args.list:
+        try:
+            procs = odin_service.list_procedures(bundle=bundle, runnable_only=args.runnable)
+        except ValueError as e:
+            p.error(str(e))
+        if args.json:
+            print(json.dumps(procs, indent=2, default=str))
+        else:
+            _print_proc_table(procs)
+        return 0
+
+    if args.backend == "bench" and not args.channel:
+        p.error("--channel required for --backend bench")
+
+    if not args.json:
+        print(f"[odin_runner] {args.procedure}  backend={args.backend}"
+              + (f" scenario={args.scenario}" if args.backend == "mock" else ""))
+    try:
+        result = odin_service.run_procedure(
+            args.procedure, backend=args.backend, bundle=bundle,
+            channel=args.channel, interface=args.interface,
+            scenario=args.scenario, verbose=args.verbose)
+    except ValueError as e:
+        p.error(str(e))
+
+    if args.json:
+        print(json.dumps(result, indent=2, default=str))
+    else:
+        print(f"\nexit_code = {result['exit_code']}")
+        print("metrics:")
+        for m in result["metrics"]:
+            print(f"  {m['metric']}: value={m['value']!r} rc={m['result_code']} "
+                  f"expected={m['expected']!r}")
+    return 0 if result["passed"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/odin_service.py
+++ b/scripts/odin_service.py
@@ -1,0 +1,484 @@
+#!/usr/bin/env python3
+"""odin_service.py -- one import surface for driving ODIN from a CLI or web app.
+
+Thin layer over the engine (odin_runner) + coverage (odin_coverage): it turns
+"which procedures can I run and what are they" and "run this one, streaming
+progress" into plain functions returning JSON-friendly data, so both the
+odin_runner CLI and the can_live call the SAME core.
+
+  * list_procedures(...)  -> [{basename, name, title, principals, valid_states,
+                               description, runnable, missing_types, has_dynamic}]
+    Reuses odin_coverage's handled-set + transitive walk to decide runnable-now,
+    and pulls the title/valid_states/principals off each entry proc's
+    comments.TaskInfo node (bench preconditions + a human-readable picker).
+
+  * run_procedure(basename, *, backend, ..., on_event) -> RunResult-as-dict
+    Wraps Engine.run_procedure. on_event(kind, payload) streams the node trace
+    ('trace'), each captured metric ('metric'), and a terminal 'done'/'error'
+    event -- the runner's _log/CaptureMetric fed through a callback instead of
+    stdout, so long procs report progress live.
+
+The ODIN bundle is NOT vendored into this (public) repo; it resolves from
+config.ODIN_BUNDLE (.env: TM3_ROOT / TM3_ODIN_BUNDLE) unless `bundle=` is passed.
+"""
+
+from __future__ import annotations
+
+import collections
+import contextlib
+import os
+from pathlib import Path
+
+import odin_coverage
+import odin_runner
+
+DEFAULT_ENTRIES = "Model3/tasks"
+
+
+# =====================================================================================
+# bundle / TaskInfo helpers
+# =====================================================================================
+def _resolve_bundle(bundle) -> Path:
+    """The networks/ bundle dir: the given `bundle`, else config.ODIN_BUNDLE."""
+    if bundle is not None:
+        return Path(bundle)
+    import config
+
+    if config.ODIN_BUNDLE is None:
+        raise ValueError("no ODIN bundle: pass bundle= or set TM3_ROOT / TM3_ODIN_BUNDLE in .env")
+    return Path(config.ODIN_BUNDLE)
+
+
+def _load_network(path: Path) -> dict | None:
+    """Exec a bundle graph file and return its top-level `network` dict (or None if
+    it doesn't parse / has no dict network). Tolerant -- used only for TaskInfo."""
+    ns: dict = {}
+    try:
+        exec(compile(path.read_text(encoding="utf-8"), str(path), "exec"), ns)  # noqa: S102
+    except Exception:  # noqa: BLE001  (a bad entry file just has no TaskInfo)
+        return None
+    net = ns.get("network")
+    return net if isinstance(net, dict) else None
+
+
+def _task_info(network: dict) -> dict | None:
+    """The graph's comments.TaskInfo node (title/valid_states/principals/...)."""
+    for node in network.values():
+        if isinstance(node, dict) and node.get("type") == "comments.TaskInfo":
+            return node
+    return None
+
+
+def _unwrap(v):
+    """TaskInfo fields are bare in the real bundle (title='...', valid_states=[...])
+    but ODIN literals elsewhere wrap as {'value': X}; accept either."""
+    if isinstance(v, dict) and "value" in v:
+        return v["value"]
+    return v
+
+
+def _as_list(v) -> list:
+    if v is None:
+        return []
+    return list(v) if isinstance(v, (list, tuple)) else [v]
+
+
+def _proc_meta(info: dict | None) -> dict:
+    """Extract the human/precondition fields off a comments.TaskInfo node."""
+    if not info:
+        return {"title": None, "principals": [], "valid_states": [], "description": None}
+    title = _unwrap(info.get("title"))
+    desc = _unwrap(info.get("description"))
+    return {
+        "title": title if isinstance(title, str) and title else None,
+        "principals": _as_list(_unwrap(info.get("principals"))),
+        "valid_states": _as_list(_unwrap(info.get("valid_states"))),
+        "description": desc if isinstance(desc, str) and desc else None,
+    }
+
+
+# =====================================================================================
+# discovery
+# =====================================================================================
+def list_procedures(
+    *, bundle=None, entries: str = DEFAULT_ENTRIES, runnable_only: bool = True
+) -> list[dict]:
+    """Every entry procedure in <bundle>/<entries>, each annotated with whether the
+    engine can run it now (all node types handled) and its TaskInfo metadata.
+
+    runnable_only=True (default) returns just the runnable set -- the picker's
+    happy path; False returns all procs with `runnable`/`missing_types` so a UI
+    can show why a proc is blocked.
+    """
+    bundle = _resolve_bundle(bundle)
+    handled = odin_coverage.handled_types()
+    entry_dir = bundle / entries
+    out: list[dict] = []
+    for f in sorted(entry_dir.glob("*.py")):
+        relbase = f"{entries}/{f.stem}"
+        types: collections.Counter = collections.Counter()
+        missing_files: set = set()
+        dynamic: list = []
+        odin_coverage.collect(bundle, relbase, set(), types, missing_files, dynamic)
+        missing = sorted(t for t in types if t not in handled)
+        runnable = not missing
+        if runnable_only and not runnable:
+            continue
+        net = _load_network(f)
+        meta = _proc_meta(_task_info(net) if net else None)
+        out.append(
+            {
+                "basename": relbase,
+                "name": f.stem,
+                "runnable": runnable,
+                "missing_types": missing,
+                "has_dynamic": bool(dynamic),
+                **meta,
+            }
+        )
+    return out
+
+
+# =====================================================================================
+# requirements  ("what must be on the bus before this proc will run")
+# =====================================================================================
+_DYNAMIC = object()  # a connection-sourced field: its value is only known at run time
+
+# CAN signal-read node types -> the "kind" label shown in the readout.
+_CAN_READ_KINDS = {
+    "can.CANSignalRead": "read",
+    "can.CANSignalMonitor": "monitor",
+    "can.CANSignalValueComparison": "compare",
+}
+# cid.* nodes that READ a named MCU data value (an environment dep, not the bus).
+_CID_READ_DATANAME = ("cid.GetDataValue", "cid.GetDataValueUntil")
+
+
+def _field_value(node: dict, key: str):
+    """Static value of a node input field: the literal it carries, None if the field
+    is absent/empty, or _DYNAMIC if it is purely a {'connection': ...} (runtime-sourced
+    with no static default).
+
+    Many ODIN fields carry BOTH a 'connection' and a 'value': the connection is the
+    runtime source, 'value' the declared default used when that connection resolves to
+    None (the networks.Input None->default fallback). We prefer that default -- it's a
+    useful, usually-correct static hint (e.g. a UDS node_name defaulting to 'PMR') --
+    so only a connection with NO default reads as _DYNAMIC. ODIN literals wrap as
+    {'value': X}; a few fields are bare (accepted as-is, mirroring _unwrap/_pull)."""
+    fld = node.get(key)
+    if isinstance(fld, dict):
+        if "value" in fld:
+            return fld["value"]
+        if "connection" in fld:
+            return _DYNAMIC
+        return None
+    return fld  # bare literal (or None)
+
+
+def _lit_str(node: dict, key: str) -> str | None:
+    """The field's value only if it's a non-empty literal string, else None."""
+    v = _field_value(node, key)
+    return v if isinstance(v, str) and v else None
+
+
+def procedure_requirements(basename: str, *, bundle=None) -> dict:
+    """Statically list what an ODIN procedure expects to be present before it runs.
+
+    Transitive over the proc's whole graph (the same referenced/inline-subnet descent
+    odin_coverage.collect uses), it gathers:
+      * signals -- CAN signals the proc READS, grouped by bus token, each with a
+        kind (read/monitor/compare).
+      * alerts  -- alert buses/prefixes it inspects (can.ActiveAlerts).
+      * nodes   -- ECU node_name(s) it does UDS to (odx.*/uds.*/EnsureApplicationState).
+      * preconditions -- valid_states (off the entry TaskInfo), the ensured
+        application_state / power_state, and MCU data-value deps (cid_values).
+      * dynamic_count -- CAN reads whose signal name is connection-sourced with no
+        declared default (only known at run time), so the signal list is a LOWER BOUND.
+
+    Bench use: a PMR/DIR bench has no gateway, so a proc that reads e.g.
+    'GTW_drivetrainType' hangs unless the operator provides it (vehicle_sim or a real
+    ECU). This readout says exactly which signals to put on the bus first.
+    """
+    import config
+
+    bundle = _resolve_bundle(bundle)
+    entry = bundle / (basename + ".py")
+    if not entry.exists():
+        raise FileNotFoundError(f"no such procedure: {basename}")
+    default_bus = config.canonical_bus(None)  # absent/dynamic bus -> vehicle backbone
+
+    signals: dict[str, list] = {}
+    seen_sig: set = set()          # (bus, signal, kind) de-dupe
+    alerts: list = []
+    seen_alert: set = set()
+    nodes: set = set()             # UDS target ECU node_names
+    cid_values: set = set()
+    app_states: list = []
+    power_states: list = []
+    counters = {"dynamic": 0}      # CAN reads with a connection-sourced signal name
+
+    def visit(name, node, relbase):
+        t = node.get("type")
+        if t in _CAN_READ_KINDS:
+            sig = _lit_str(node, "signal_name")
+            if sig is None:
+                counters["dynamic"] += 1   # connection-sourced (or missing) signal name
+                return
+            bus = _lit_str(node, "bus_name") or default_bus
+            key = (bus, sig, _CAN_READ_KINDS[t])
+            if key not in seen_sig:
+                seen_sig.add(key)
+                signals.setdefault(bus, []).append({"signal": sig, "kind": _CAN_READ_KINDS[t]})
+        elif t == "can.ActiveAlerts":
+            key = (_lit_str(node, "bus_name"), _lit_str(node, "prefix"))
+            if key not in seen_alert:
+                seen_alert.add(key)
+                alerts.append({"bus": key[0], "prefix": key[1]})
+        elif t and (t.startswith("odx.") or t.startswith("uds.")):
+            nn = _lit_str(node, "node_name")
+            if nn:
+                nodes.add(nn)
+        elif t == "vehiclecontrols.EnsureApplicationState":
+            nn = _lit_str(node, "node_name")
+            if nn:
+                nodes.add(nn)
+            st = _lit_str(node, "application_state")
+            if st and st not in app_states:
+                app_states.append(st)
+        elif t in ("vehiclecontrols.PowerContext", "vehiclecontrols.EnsurePowerState"):
+            st = _lit_str(node, "power_state")
+            if st and st not in power_states:
+                power_states.append(st)
+        elif t in _CID_READ_DATANAME:
+            dn = _lit_str(node, "data_name")
+            if dn:
+                cid_values.add(dn)
+        elif t == "cid.ListDataValues":
+            dv = _field_value(node, "dv")
+            for n in dv if isinstance(dv, (list, tuple)) else []:
+                if isinstance(n, str) and n:
+                    cid_values.add(n)
+
+    odin_coverage.collect(bundle, basename, set(), collections.Counter(), set(), [], visit=visit)
+
+    net = _load_network(entry)
+    valid_states = _proc_meta(_task_info(net) if net else None)["valid_states"]
+    for lst in signals.values():
+        lst.sort(key=lambda s: (s["signal"], s["kind"]))
+
+    return {
+        "basename": basename,
+        "signals": signals,
+        "alerts": alerts,
+        "nodes": sorted(nodes),
+        "preconditions": {
+            "valid_states": valid_states,
+            "application_state": app_states[0] if app_states else None,
+            "power_state": power_states[0] if power_states else None,
+            "cid_values": sorted(cid_values),
+        },
+        "dynamic_count": counters["dynamic"],
+    }
+
+
+# =====================================================================================
+# run
+# =====================================================================================
+def _resolve_backend(backend, *, scenario, channel, interface):
+    """Return (backend_instance, we_created_it). Accepts a Backend instance (used
+    as-is, caller owns it) or a string 'mock'/'bench' (built with .env defaults)."""
+    if isinstance(backend, odin_runner.Backend):
+        return backend, False
+    key = str(backend).lower()
+    if key == "mock":
+        return odin_runner.MockBackend(scenario), True
+    if key == "bench":
+        import config
+
+        ch = channel or config.VEHICLE_CHANNEL
+        if not ch:
+            raise ValueError(
+                "bench backend needs a CAN channel (pass channel= or set TM3_VEHICLE_CHANNEL)"
+            )
+        iface = interface or os.environ.get("TM3_INTERFACE") or "socketcan"
+        return odin_runner.BenchBackend(ch, iface), True
+    raise ValueError(f"unknown backend {backend!r}: use 'mock', 'bench', or a Backend instance")
+
+
+def _result_dict(basename: str, result: odin_runner.RunResult) -> dict:
+    return {
+        "basename": basename,
+        "exit_code": result.exit_code,
+        "passed": result.exit_code == 0,
+        "metrics": result.metrics,
+        "outputs": result.outputs,
+    }
+
+
+def run_procedure(
+    basename: str,
+    *,
+    backend="mock",
+    bundle=None,
+    channel=None,
+    interface=None,
+    scenario: str = "success",
+    on_event=None,
+    verbose: bool = False,
+    time_scale=None,
+) -> dict:
+    """Run one ODIN procedure and return its RunResult as a JSON-friendly dict
+    ({basename, exit_code, passed, metrics, outputs}).
+
+    backend: a odin_runner.Backend instance, or 'mock'/'bench'. A bench backend
+    talks real UDS/CAN (needs channel); mock scripts the resolver-learn
+    choreography offline. on_event(kind, payload) streams 'trace'/'metric' events
+    during the run and a final 'done' (or 'error') event. time_scale defaults to
+    real timings on the bench and instant (no sleeps) otherwise.
+    """
+    bundle = _resolve_bundle(bundle)
+    be, owns = _resolve_backend(backend, scenario=scenario, channel=channel, interface=interface)
+    if time_scale is None:
+        time_scale = 1.0 if isinstance(be, odin_runner.BenchBackend) else 0.0
+    eng = odin_runner.Engine(be, bundle, verbose=verbose, time_scale=time_scale, on_event=on_event)
+    try:
+        result = eng.run_procedure(basename)
+    except Exception as e:  # noqa: BLE001  (surface the failure to a streaming caller)
+        if on_event is not None:
+            with contextlib.suppress(Exception):
+                on_event("error", {"basename": basename, "error": str(e)})
+        raise
+    finally:
+        if owns:
+            getattr(be, "close", lambda: None)()
+    out = _result_dict(basename, result)
+    if on_event is not None:
+        with contextlib.suppress(Exception):
+            on_event("done", out)
+    return out
+
+
+# =====================================================================================
+# DID read / write (0x22 / 0x2E)
+# =====================================================================================
+# The non-interactive core of tm3diag's _did_menu / _did_write_menu: resolve a DID
+# name-or-id off the node's ODJ (NodeConfig.dids), decode a read response and encode
+# a write payload via odj_codec (the SAME table-driven codec the ODIN runner's odx.*
+# nodes use), and run SecurityAccess when the DID's subspec demands a level. Both the
+# terminal menus and the coming can_live/CLI DID surface call these, so there is one
+# encode/decode path (no hand-packed duplicate). Functions take an already-opened
+# (sess, cfg): sess is a uds_local.UdsSession (or any object with read_did/write_did/
+# diagnostic_session/security_access), cfg a NodeConfig.
+def _resolve_did(cfg, name_or_id):
+    """Resolve a DID name or id (int, '0xNNNN', or decimal str) to
+    (name, OdjEntry|None, did_id). entry is None for a raw id not in the node's ODJ."""
+    if isinstance(name_or_id, int):
+        did_id = name_or_id
+    else:
+        s = str(name_or_id).strip()
+        if s in cfg.dids:
+            e = cfg.dids[s]
+            return s, e, e.hex_id
+        try:
+            did_id = int(s, 16) if s.lower().startswith("0x") else int(s, 0)
+        except ValueError as exc:
+            raise KeyError(f"unknown DID {name_or_id!r} for node {cfg.name}") from exc
+    for n, e in cfg.dids.items():
+        if e.hex_id == did_id:
+            return n, e, did_id
+    return f"0x{did_id:04X}", None, did_id
+
+
+def _apply_did_security(sess, level) -> None:
+    """Enter programming session + run SecurityAccess for a DID's required level."""
+    if level:
+        from uds_local.client import _SESSION_PROGRAMMING
+
+        sess.diagnostic_session(_SESSION_PROGRAMMING)
+        sess.security_access(seed_level=level)
+
+
+def _did_meta(name, entry, sub) -> dict:
+    """Picker-friendly metadata for one DID subspec (read.output / write.input)."""
+    return {
+        "name": name,
+        "id": entry.hex_id,
+        "hex_id": f"0x{entry.hex_id:04X}",
+        "size": (sub.output_size if sub is entry.read else sub.input_size),
+        "security_level": sub.security_level,
+        "fields": list((sub.output if sub is entry.read else sub.input).keys()),
+    }
+
+
+def list_dids(cfg) -> dict:
+    """The node's readable + writable DIDs as {'read': [...], 'write': [...]} lists of
+    metadata dicts (name, id, hex_id, size, security_level, fields), name-sorted."""
+    read, write = [], []
+    for name, e in sorted(cfg.dids.items()):
+        if e.read is not None:
+            read.append(_did_meta(name, e, e.read))
+        if e.write is not None:
+            write.append(_did_meta(name, e, e.write))
+    return {"read": read, "write": write}
+
+
+def read_did(sess, cfg, name_or_id, *, parsed: bool = True, security: bool = True) -> dict:
+    """ReadDataByIdentifier (0x22): resolve the DID, run SecurityAccess if its read
+    subspec needs a level, read, and decode per the ODJ FieldSpecs.
+
+    Returns {name, id, hex_id, raw (hex str), fields ({field: value})}. `fields` is
+    empty for a raw id with no ODJ read subspec (the caller still gets `raw`).
+    parsed=True applies enum maps (raw number -> enum name); False keeps raw numbers.
+    """
+    from uds_local.odj_codec import decode_response
+
+    name, entry, did_id = _resolve_did(cfg, name_or_id)
+    sub = entry.read if entry else None
+    if security and sub is not None:
+        _apply_did_security(sess, sub.security_level)
+    raw = bytes(sess.read_did(did_id))
+    return {
+        "name": name,
+        "id": did_id,
+        "hex_id": f"0x{did_id:04X}",
+        "raw": raw.hex(),
+        "fields": decode_response(sub, raw, parsed=parsed),
+    }
+
+
+def _encode_write(entry, values) -> bytes:
+    """Encode a write payload from a {field: value} dict (via odj_codec, enum names
+    accepted) or pass raw bytes / a hex string straight through."""
+    from uds_local.odj_codec import encode_request
+
+    if isinstance(values, (bytes, bytearray)):
+        return bytes(values)
+    if isinstance(values, str):
+        return bytes.fromhex(values.replace(" ", ""))
+    return encode_request(entry.write if entry else None, values or {})
+
+
+def encode_did_write(cfg, name_or_id, values) -> tuple:
+    """Build the write payload for a DID -> (name, did_id, bytes), without sending.
+    Exposed so a caller can show/confirm the exact bytes before the write goes out."""
+    name, entry, did_id = _resolve_did(cfg, name_or_id)
+    return name, did_id, _encode_write(entry, values)
+
+
+def write_did(sess, cfg, name_or_id, values, *, security: bool = True) -> dict:
+    """WriteDataByIdentifier (0x2E): encode `values` (see encode_did_write), run
+    SecurityAccess if the write subspec needs a level, and write. Returns
+    {name, id, hex_id, bytes (hex str), size}."""
+    name, entry, did_id = _resolve_did(cfg, name_or_id)
+    data = _encode_write(entry, values)
+    sub = entry.write if entry else None
+    if security and sub is not None:
+        _apply_did_security(sess, sub.security_level)
+    sess.write_did(did_id, data)
+    return {
+        "name": name,
+        "id": did_id,
+        "hex_id": f"0x{did_id:04X}",
+        "bytes": data.hex(),
+        "size": len(data),
+    }

--- a/scripts/odin_web.py
+++ b/scripts/odin_web.py
@@ -1,0 +1,564 @@
+#!/usr/bin/env python3
+"""odin_web.py -- aiohttp route glue exposing the ODIN runner + DID read/write over
+HTTP + WebSocket, for the can_live.
+
+All the logic lives here; can_live wires it in with a single setup_routes(app, ...)
+call, so the interface gets:
+  * GET  /api/odin/procedures[?all=1]  -> the runnable (or full) procedure list
+  * GET  /api/odin/requirements?procedure=<basename>
+                                       -> what the proc expects on the bus (the CAN
+                                          signals it reads, alert buses, UDS target
+                                          nodes, preconditions) -- see
+                                          odin_service.procedure_requirements.
+  * POST /api/odin/run {procedure}     -> run one proc; returns the RunResult dict.
+                                          Progress (trace/metric/done/error events)
+                                          is broadcast to /ws/odin while it runs.
+  * GET  /ws/odin                      -> server->client progress stream
+  * GET  /api/did/{node}               -> the node's readable/writable DIDs
+  * POST /api/did/read  {node, did}    -> read + decode a DID
+  * POST /api/did/write {node, did, values} -> write a DID
+  * GET  /api/uds/nodes                -> UDS-addressable nodes (name + tx/rx ids),
+                                          so the UI can offer a picker instead of a
+                                          free-text box
+  * GET  /api/uds/ops                  -> the low-level UDS operation catalog
+                                          (id, args, danger flag) -- the UI builds
+                                          its form from this.
+  * POST /api/uds/op {node, op, args}  -> run one low-level UDS operation
+
+The Engine is SYNCHRONOUS (real sleeps on the bench), so a run goes through
+loop.run_in_executor; the runner's on_event callback (called from the executor
+thread) hands events back to the loop via call_soon_threadsafe -> an asyncio.Queue
+-> the /ws/odin broadcast. One run at a time (a lock; a second run gets 409).
+
+Backends/sessions are injected so this is testable with no bus:
+  * backend_factory() -> a odin_runner.Backend (or 'mock'/'bench'); default 'mock'.
+  * node_provider(node) -> (NodeConfig, session) for DID ops; without it, the DID
+    read/write endpoints report 503 (no bench).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import functools
+import json
+
+import odin_service
+from aiohttp import web
+
+
+def _json(obj, status: int = 200) -> web.Response:
+    """JSON response tolerant of non-serializable values (bytes, etc. -> str)."""
+    return web.json_response(obj, status=status, dumps=lambda o: json.dumps(o, default=str))
+
+
+class OdinWeb:
+    """Holds the run lock, the /ws/odin client set, and the injected backend/node
+    sources; one instance per aiohttp app (stored at app['odin_web'])."""
+
+    def __init__(self, *, bundle=None, backend_factory=None, node_provider=None):
+        self.bundle = bundle
+        self._backend_factory = backend_factory  # () -> Backend | 'mock'/'bench'
+        self._node_provider = node_provider  # (node) -> (NodeConfig, session)
+        self._proc_cache: list | None = None
+        self._req_cache: dict[str, dict] = {}  # basename -> procedure_requirements (static)
+        self._run_lock = asyncio.Lock()  # one ODIN run at a time
+        self.clients: set[web.WebSocketResponse] = set()
+
+    # -- ODIN: discovery ---------------------------------------------------------
+    async def list_procedures(self, *, runnable_only: bool = True) -> list:
+        # list_procedures walks the whole bundle (blocking) -> executor + cache.
+        if self._proc_cache is None:
+            loop = asyncio.get_running_loop()
+            self._proc_cache = await loop.run_in_executor(
+                None,
+                functools.partial(
+                    odin_service.list_procedures, bundle=self.bundle, runnable_only=False
+                ),
+            )
+        if runnable_only:
+            return [p for p in self._proc_cache if p["runnable"]]
+        return self._proc_cache
+
+    async def _h_procedures(self, request: web.Request) -> web.Response:
+        runnable = request.query.get("all", "") not in ("1", "true", "yes")
+        try:
+            procs = await self.list_procedures(runnable_only=runnable)
+        except ValueError as e:  # no bundle configured
+            return _json({"error": str(e)}, status=503)
+        return _json(procs)
+
+    async def requirements(self, basename: str) -> dict:
+        # procedure_requirements walks the proc's whole graph (blocking file I/O) ->
+        # executor + per-basename cache (the bundle is static at runtime).
+        if basename not in self._req_cache:
+            loop = asyncio.get_running_loop()
+            self._req_cache[basename] = await loop.run_in_executor(
+                None,
+                functools.partial(
+                    odin_service.procedure_requirements, basename, bundle=self.bundle
+                ),
+            )
+        return self._req_cache[basename]
+
+    async def _h_requirements(self, request: web.Request) -> web.Response:
+        proc = request.query.get("procedure")
+        if not proc:
+            return _json({"error": "missing 'procedure'"}, status=400)
+        try:
+            return _json(await self.requirements(proc))
+        except FileNotFoundError as e:  # unknown procedure basename
+            return _json({"error": str(e)}, status=404)
+        except ValueError as e:  # no bundle configured
+            return _json({"error": str(e)}, status=503)
+
+    # -- ODIN: run + progress ----------------------------------------------------
+    async def _h_run(self, request: web.Request) -> web.Response:
+        try:
+            body = await request.json()
+        except Exception:  # noqa: BLE001
+            return _json({"error": "invalid JSON"}, status=400)
+        proc = body.get("procedure")
+        if not proc:
+            return _json({"error": "missing 'procedure'"}, status=400)
+        if self._run_lock.locked():
+            return _json({"error": "a run is already in progress"}, status=409)
+        async with self._run_lock:
+            try:
+                result = await self._run(proc)
+            except Exception as e:  # noqa: BLE001  (surface a run failure as 500)
+                return _json({"error": str(e), "procedure": proc}, status=500)
+        return _json(result)
+
+    async def _run(self, proc: str) -> dict:
+        loop = asyncio.get_running_loop()
+        # Build the backend FIRST: if backend_factory raises (e.g. no CAN channel),
+        # fail before the pump task starts so nothing leaks.
+        backend = self._backend_factory() if self._backend_factory else "mock"
+        q: asyncio.Queue = asyncio.Queue()
+
+        def emit(kind, payload):  # called from the executor thread
+            loop.call_soon_threadsafe(q.put_nowait, (kind, payload))
+
+        pump = asyncio.create_task(self._pump(q))
+        try:
+            return await loop.run_in_executor(
+                None,
+                functools.partial(
+                    odin_service.run_procedure,
+                    proc,
+                    backend=backend,
+                    bundle=self.bundle,
+                    on_event=emit,
+                ),
+            )
+        finally:
+            await q.put(None)  # sentinel: all events already queued (FIFO) -> stop pump
+            await pump
+
+    async def _pump(self, q: asyncio.Queue) -> None:
+        while True:
+            item = await q.get()
+            if item is None:
+                return
+            kind, payload = item
+            msg = (
+                {"type": kind, **payload}
+                if isinstance(payload, dict)
+                else {"type": kind, "value": payload}
+            )
+            await self._broadcast(msg)
+
+    async def _broadcast(self, msg: dict) -> None:
+        if not self.clients:
+            return
+        text = json.dumps(msg, default=str)
+        for ws in list(self.clients):
+            try:
+                await ws.send_str(text)
+            except Exception:  # noqa: BLE001  (drop a dead client)
+                self.clients.discard(ws)
+
+    async def _h_ws(self, request: web.Request) -> web.WebSocketResponse:
+        ws = web.WebSocketResponse(heartbeat=30.0)
+        await ws.prepare(request)
+        self.clients.add(ws)
+        try:
+            async for _msg in ws:  # progress is server->client only; ignore inbound
+                pass
+        finally:
+            self.clients.discard(ws)
+        return ws
+
+    # -- DID read/write ----------------------------------------------------------
+    async def _node(self, node: str):
+        if self._node_provider is None:
+            raise web.HTTPServiceUnavailable(
+                text="DID access needs a bench backend (no node provider configured)"
+            )
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(None, self._node_provider, node)
+
+    async def _h_did_list(self, request: web.Request) -> web.Response:
+        try:
+            cfg, _sess = await self._node(request.match_info["node"])
+        except web.HTTPException as e:
+            return _json({"error": e.text}, status=e.status)
+        except Exception as e:  # noqa: BLE001  (unknown node, load failure)
+            return _json({"error": str(e)}, status=400)
+        return _json(odin_service.list_dids(cfg))
+
+    async def _h_did_read(self, request: web.Request) -> web.Response:
+        return await self._did_op(request, write=False)
+
+    async def _h_did_write(self, request: web.Request) -> web.Response:
+        return await self._did_op(request, write=True)
+
+    async def _did_op(self, request: web.Request, *, write: bool) -> web.Response:
+        try:
+            body = await request.json()
+        except Exception:  # noqa: BLE001
+            return _json({"error": "invalid JSON"}, status=400)
+        node, did = body.get("node"), body.get("did")
+        if not node or did is None:
+            return _json({"error": "missing 'node' or 'did'"}, status=400)
+        try:
+            cfg, sess = await self._node(node)
+        except web.HTTPException as e:
+            return _json({"error": e.text}, status=e.status)
+        except Exception as e:  # noqa: BLE001
+            return _json({"error": str(e)}, status=400)
+        loop = asyncio.get_running_loop()
+        try:
+            if write:
+                call = functools.partial(odin_service.write_did, sess, cfg, did, body.get("values"))
+            else:
+                call = functools.partial(
+                    odin_service.read_did, sess, cfg, did, parsed=body.get("parsed", True)
+                )
+            res = await loop.run_in_executor(None, call)
+        except Exception as e:  # noqa: BLE001  (UDS/decode/unknown-DID error)
+            return _json({"error": str(e)}, status=400)
+        return _json(res)
+
+    # -- low-level UDS ops -------------------------------------------------------
+    async def _h_uds_nodes(self, request: web.Request) -> web.Response:
+        """Every node with a UDS request/response pair in nodes.json. Static config,
+        not bus state, so it needs no backend -- the DID and low-level tabs both
+        populate their node picker from it."""
+        try:
+            nodes = await asyncio.get_running_loop().run_in_executor(None, _list_uds_nodes)
+        except Exception as e:  # noqa: BLE001  (missing/!readable config)
+            return _json({"error": str(e)}, status=503)
+        return _json(nodes)
+
+    async def _h_uds_ops(self, request: web.Request) -> web.Response:
+        return _json(UDS_OPS)
+
+    async def _h_uds_run(self, request: web.Request) -> web.Response:
+        try:
+            body = await request.json()
+        except Exception:  # noqa: BLE001
+            return _json({"error": "invalid JSON"}, status=400)
+        node, op = body.get("node"), body.get("op")
+        if not node or not op:
+            return _json({"error": "missing 'node' or 'op'"}, status=400)
+        if op not in _UDS_OPS_BY_ID:
+            return _json({"error": f"unknown operation: {op}"}, status=400)
+        try:
+            _cfg, sess = await self._node(node)
+        except web.HTTPException as e:
+            return _json({"error": e.text}, status=e.status)
+        except Exception as e:  # noqa: BLE001  (unknown node, load failure)
+            return _json({"error": str(e)}, status=400)
+        # A reset or bootloader handover must not land mid-procedure.
+        if self._run_lock.locked():
+            return _json({"error": "a procedure run is in progress"}, status=409)
+        backend = self._backend_factory() if self._backend_factory else None
+        loop = asyncio.get_running_loop()
+        async with self._run_lock:
+            try:
+                res = await loop.run_in_executor(
+                    None,
+                    functools.partial(_run_uds_op, backend, sess, node, op, body.get("args") or {}),
+                )
+            except Exception as e:  # noqa: BLE001  (UDS/NRC/timeout/bad arg)
+                return _json({"error": f"{type(e).__name__}: {e}", "op": op}, status=400)
+        return _json({"op": op, "node": node, "result": res})
+
+
+# ---------------------------------------------------------------------------
+# Low-level UDS operations
+# ---------------------------------------------------------------------------
+# The primitives the ODIN procedures are built out of, exposed on their own: when
+# you are bringing a bench ECU up, no packaged procedure covers "put this node in
+# its bootloader and tell me what it thinks it is". Every op maps to a method that
+# already exists on UdsSession (or, for the bootloader pair, to the backend's
+# ensure_application_state -- the same reset + TesterPresent-flood handover the
+# flasher uses, so the state tracking stays consistent with a subsequent run).
+#
+# The catalog is data: the UI renders a form per op from `fields` and refuses to
+# fire a `danger` op without a confirm. Keep the two in sync by adding here only.
+
+_SESSION_MODES = {"default": 0x01, "programming": 0x02, "extended": 0x03, "safety": 0x04}
+
+_RESET_TYPES = {"hard": 0x01, "key-off-on": 0x02, "soft": 0x03}
+
+UDS_OPS: list[dict] = [
+    {
+        "op": "probe_state",
+        "title": "Probe state",
+        "group": "state",
+        "help": "Read 0xF180 (fw_type byte) and probe 0xF181 to tell bootloader from app.",
+    },
+    {
+        "op": "enter_bootloader",
+        "title": "Enter bootloader",
+        "group": "state",
+        "danger": True,
+        "help": "ECUReset, then flood TesterPresent through the reboot so the "
+                "bootloader holds instead of booting on into the app.",
+    },
+    {
+        "op": "enter_application",
+        "title": "Enter application",
+        "group": "state",
+        "danger": True,
+        "help": "ECUReset with no keep-alive flood: the bootloader boots on into the app.",
+    },
+    {
+        "op": "ecu_reset",
+        "title": "ECU reset",
+        "group": "state",
+        "danger": True,
+        "help": "Raw ECUReset (0x11). 'no wait' sends 11 81 fire-and-forget.",
+        "fields": [
+            {"name": "type", "label": "reset type", "type": "select",
+             "options": list(_RESET_TYPES), "default": "hard"},
+            {"name": "no_wait", "label": "fire and forget", "type": "bool", "default": False},
+        ],
+    },
+    {
+        "op": "session",
+        "title": "Diagnostic session",
+        "group": "session",
+        "help": "DiagnosticSessionControl (0x10).",
+        "fields": [
+            {"name": "mode", "label": "mode", "type": "select",
+             "options": list(_SESSION_MODES), "default": "extended"},
+        ],
+    },
+    {
+        "op": "security_access",
+        "title": "Security access",
+        "group": "session",
+        "help": "Seed/key exchange (0x27) using the node's configured algorithm. "
+                "Most nodes want a programming session first.",
+        "fields": [
+            {"name": "level_idx", "label": "level index", "type": "int", "default": 0},
+        ],
+    },
+    {
+        "op": "tester_present",
+        "title": "TesterPresent keepalive",
+        "group": "session",
+        "help": "Start or stop the background 0x3E keep-alive on this node's session.",
+        "fields": [
+            {"name": "on", "label": "running", "type": "bool", "default": True},
+        ],
+    },
+    {
+        "op": "read_did_raw",
+        "title": "Read DID (raw)",
+        "group": "diagnostics",
+        "help": "ReadDataByIdentifier (0x22) by number, returning raw bytes -- no ODJ "
+                "decode, so it reaches DIDs the DID tab does not list.",
+        "fields": [
+            {"name": "did", "label": "DID (hex)", "type": "hex16", "default": "F180"},
+        ],
+    },
+    {
+        "op": "routine_control",
+        "title": "Routine control",
+        "group": "diagnostics",
+        "danger": True,
+        "help": "RoutineControl (0x31). Subtype 1=start, 2=stop, 3=request results.",
+        "fields": [
+            {"name": "routine_id", "label": "routine (hex)", "type": "hex16", "default": ""},
+            {"name": "subtype", "label": "subtype", "type": "int", "default": 1},
+            {"name": "arg", "label": "argument (hex bytes)", "type": "hexbytes", "default": ""},
+        ],
+    },
+    {
+        "op": "read_dtcs",
+        "title": "Read DTCs",
+        "group": "diagnostics",
+        "help": "ReadDTCInformation (0x19) by status mask.",
+        "fields": [
+            {"name": "status_mask", "label": "status mask", "type": "int", "default": 255},
+        ],
+    },
+    {
+        "op": "clear_dtc",
+        "title": "Clear DTCs",
+        "group": "diagnostics",
+        "danger": True,
+        "help": "ClearDiagnosticInformation (0x14), group 0xFFFFFF by default.",
+        "fields": [
+            {"name": "group", "label": "group (hex)", "type": "hex24", "default": "FFFFFF"},
+        ],
+    },
+]
+
+_UDS_OPS_BY_ID = {o["op"]: o for o in UDS_OPS}
+
+_uds_node_cache: list[dict] | None = None
+
+
+def _list_uds_nodes() -> list[dict]:
+    """(name, tx, rx) for every UDS-addressable node, sorted and cached -- the file
+    is static for the life of the process."""
+    global _uds_node_cache
+    if _uds_node_cache is None:
+        import config as _cfg
+        from uds_local.node_config import load_all_nodes
+
+        _uds_node_cache = [
+            {"node": name, "tx": f"0x{tx:03X}", "rx": f"0x{rx:03X}"}
+            for name, tx, rx in sorted(load_all_nodes(_cfg.NODES_JSON, _cfg.ETH_COMPACT))
+        ]
+    return _uds_node_cache
+
+
+def _as_hex_int(val, default: int = 0) -> int:
+    """Parse a hex-typed field: 0xF180, F180, "f180" or an already-int value.
+    HEX, not decimal -- every caller is a DID / routine / DTC-group field, where
+    the user types hex without thinking about it."""
+    if val is None or val == "":
+        return default
+    if isinstance(val, bool):
+        return int(val)
+    if isinstance(val, int):
+        return val
+    text = str(val).strip().replace(" ", "")
+    return int(text, 16) if text.lower().startswith("0x") else int(text, 16)
+
+
+def _as_bytes(val) -> bytes:
+    if not val:
+        return b""
+    return bytes.fromhex(str(val).replace(" ", "").removeprefix("0x"))
+
+
+def _probe_state(sess) -> dict:
+    """Mirror flash_scripts._steps.step_probe_bootloader_state: fw_type from 0xF180
+    byte 8, cross-checked against whether 0xF181 (app-only) answers."""
+    out: dict = {}
+    try:
+        f180 = sess.read_did(0xF180)
+        out["f180"] = f180.hex()
+        if len(f180) >= 9:
+            fw_type = f180[8]
+            out["fw_type"] = fw_type
+            out["state"] = "BOOTLOADER" if fw_type == 0 else "APPLICATION"
+    except Exception as e:  # noqa: BLE001
+        out["f180_error"] = f"{type(e).__name__}: {e}"
+    try:
+        sess.read_did(0xF181)
+        out["f181"] = "present (app)"
+    except Exception:  # noqa: BLE001
+        out["f181"] = "NRC (bootloader)"
+    return out
+
+
+def _run_uds_op(backend, sess, node: str, op: str, args: dict) -> dict:
+    """Blocking; called in an executor. Returns a JSON-able result dict."""
+    spec = _UDS_OPS_BY_ID.get(op)
+    if spec is None:
+        raise ValueError(f"unknown operation: {op!r}")
+
+    if op == "probe_state":
+        return _probe_state(sess)
+
+    if op in ("enter_bootloader", "enter_application"):
+        state = "BOOTLOADER" if op == "enter_bootloader" else "APPLICATION"
+        if not hasattr(backend, "ensure_application_state"):
+            raise RuntimeError(
+                "bootloader handover needs the bench backend (none configured)"
+            )
+        backend.ensure_application_state(node, state)
+        return {"state": state, "probe": _probe_state(sess)}
+
+    if op == "ecu_reset":
+        rtype = _RESET_TYPES.get(str(args.get("type", "hard")), 0x01)
+        if args.get("no_wait"):
+            sess.ecu_reset_no_wait(rtype)
+            return {"sent": f"11 8{rtype:X}", "waited": False}
+        sess.ecu_reset(rtype)
+        return {"sent": f"11 0{rtype:X}", "waited": True}
+
+    if op == "session":
+        mode = _SESSION_MODES.get(str(args.get("mode", "extended")))
+        if mode is None:
+            mode = _as_hex_int(args.get("mode"), 0x03)
+        sess.diagnostic_session(mode)
+        return {"session": f"0x{mode:02X}"}
+
+    if op == "security_access":
+        sess.security_access(int(args.get("level_idx") or 0))
+        return {"granted": True, "level_idx": int(args.get("level_idx") or 0)}
+
+    if op == "tester_present":
+        if args.get("on", True):
+            sess.start_tester_present()
+            return {"tester_present": "started"}
+        sess.stop_tester_present()
+        return {"tester_present": "stopped"}
+
+    if op == "read_did_raw":
+        did = _as_hex_int(args.get("did"))
+        data = sess.read_did(did)
+        return {"did": f"0x{did:04X}", "raw": data.hex(), "length": len(data)}
+
+    if op == "routine_control":
+        rid = _as_hex_int(args.get("routine_id"))
+        result = sess.routine_control(rid, _as_bytes(args.get("arg")),
+                                      int(args.get("subtype") or 1))
+        return {"routine": f"0x{rid:04X}", "result": result.hex() if result else ""}
+
+    if op == "read_dtcs":
+        mask = int(args.get("status_mask") or 0xFF)
+        dtcs = sess.read_dtcs(mask)
+        return {"count": len(dtcs),
+                "dtcs": [{"dtc": f"0x{k:06X}", "status": f"0x{v:02X}"} for k, v in dtcs.items()]}
+
+    if op == "clear_dtc":
+        group = _as_hex_int(args.get("group"), 0xFFFFFF)
+        sess.clear_dtc(group)
+        return {"cleared": f"0x{group:06X}"}
+
+    raise ValueError(f"operation not implemented: {op!r}")  # pragma: no cover
+
+# Typed app key (aiohttp warns on bare-string keys); can_live can read the instance
+# back via app[odin_web.ODIN_WEB], though setup_routes also returns it.
+ODIN_WEB = web.AppKey("odin_web", OdinWeb)
+
+
+def setup_routes(
+    app: web.Application, *, bundle=None, backend_factory=None, node_provider=None, prefix: str = ""
+) -> OdinWeb:
+    """Register the ODIN + DID routes on `app` and return the OdinWeb instance.
+    can_live calls this once from _build_app. See the module docstring for the
+    backend_factory / node_provider seams."""
+    svc = OdinWeb(bundle=bundle, backend_factory=backend_factory, node_provider=node_provider)
+    app[ODIN_WEB] = svc
+    app.router.add_get(prefix + "/api/odin/procedures", svc._h_procedures)
+    app.router.add_get(prefix + "/api/odin/requirements", svc._h_requirements)
+    app.router.add_post(prefix + "/api/odin/run", svc._h_run)
+    app.router.add_get(prefix + "/ws/odin", svc._h_ws)
+    app.router.add_get(prefix + "/api/did/{node}", svc._h_did_list)
+    app.router.add_post(prefix + "/api/did/read", svc._h_did_read)
+    app.router.add_post(prefix + "/api/did/write", svc._h_did_write)
+    app.router.add_get(prefix + "/api/uds/nodes", svc._h_uds_nodes)
+    app.router.add_get(prefix + "/api/uds/ops", svc._h_uds_ops)
+    app.router.add_post(prefix + "/api/uds/op", svc._h_uds_run)
+    return svc

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,10 @@
+"""Shared pytest setup: make the top-level scripts/ dir importable.
+
+odin_runner.py (and its siblings) live in scripts/, which is not on sys.path by
+default when pytest runs from the repo root. Prepend it so tests can
+`import odin_runner` the same way the CLI does.
+"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))

--- a/tests/test_datastore.py
+++ b/tests/test_datastore.py
@@ -1,0 +1,63 @@
+"""Tests for uds_local/datastore.py (the board-keyed interop store).
+
+All isolated to a tmp file -- nothing touches the real odin_data.json.
+"""
+from uds_local.datastore import DataStore, json_safe
+
+
+class TestJsonSafe:
+    def test_bytes_to_hex_recursive(self):
+        out = json_safe({"blob": b"\xff\xff",
+                         "n": {"table": b"\xfe\x85", "v": 1},
+                         "list": [b"\x00", 2]})
+        assert out == {"blob": "ffff", "n": {"table": "fe85", "v": 1},
+                       "list": ["00", 2]}
+
+    def test_passthrough(self):
+        assert json_safe({"a": 1, "b": "x", "c": [1, 2]}) == {"a": 1, "b": "x", "c": [1, 2]}
+
+
+def _store(tmp_path):
+    return DataStore(tmp_path / "odin_data.json")
+
+
+class TestDataStore:
+    def test_put_get_roundtrip_and_persist(self, tmp_path):
+        s = _store(tmp_path)
+        s.put("SN123", "outputs", "DRIVE_UNIT_ODOMETER", 4)
+        s.update("SN123", "outputs", {"odin_output": "DI rotations: 4"})
+        assert s.get("SN123", "outputs") == {
+            "DRIVE_UNIT_ODOMETER": 4, "odin_output": "DI rotations: 4"}
+        # a fresh DataStore on the same file sees the persisted data
+        assert DataStore(tmp_path / "odin_data.json").get("SN123", "outputs") == {
+            "DRIVE_UNIT_ODOMETER": 4, "odin_output": "DI rotations: 4"}
+
+    def test_missing_returns_empty(self, tmp_path):
+        s = _store(tmp_path)
+        assert s.get("nope", "outputs") == {} and s.has("nope", "outputs") is False
+        assert s.boards() == []
+
+    def test_namespaces_are_independent(self, tmp_path):
+        s = _store(tmp_path)
+        s.update("SN1", "immo", {"key": "aa"})
+        s.update("SN1", "outputs", {"x": 1})
+        assert s.get("SN1", "immo") == {"key": "aa"}
+        assert s.get("SN1", "outputs") == {"x": 1}
+        assert s.boards() == ["SN1"]
+
+    def test_update_replace(self, tmp_path):
+        s = _store(tmp_path)
+        s.update("SN1", "outputs", {"a": 1, "b": 2})
+        s.update("SN1", "outputs", {"c": 3}, replace=True)
+        assert s.get("SN1", "outputs") == {"c": 3}
+
+    def test_get_returns_copy(self, tmp_path):
+        s = _store(tmp_path)
+        s.update("SN1", "outputs", {"a": 1})
+        s.get("SN1", "outputs")["a"] = 999   # mutating the copy must not persist
+        assert s.get("SN1", "outputs") == {"a": 1}
+
+    def test_corrupt_file_loads_empty(self, tmp_path):
+        p = tmp_path / "odin_data.json"
+        p.write_text("{ not json")
+        assert DataStore(p).boards() == []

--- a/tests/test_odin_bench.py
+++ b/tests/test_odin_bench.py
@@ -1,0 +1,403 @@
+"""Tests for the odin_runner BenchBackend odx/uds adapters + Engine handlers.
+
+Self-contained: a FakeSession stands in for uds_local.UdsSession (records calls,
+returns canned bytes) and a synthetic NodeConfig supplies the ODJ routine/DID
+specs, so these run with no bench and no firmware data. The RESOLVER_LEARNING
+results spec mirrors the real DIR ODJ (see test_odj_codec).
+"""
+import struct
+from pathlib import Path
+
+import can
+import odin_runner
+from odin_runner import BenchBackend, Engine, _CanRxCache, _OdxAdapter, _UdsAdapter
+
+from uds_local.client import UdsSession
+from uds_local.node_config import NodeConfig
+from uds_local.odj import FieldSpec, OdjEntry, RoutineEntry, SubSpec
+
+
+def _fs(bit_length, byte_position, bit_position=0, data_type="uint", enum=None):
+    return FieldSpec(bit_length=bit_length, byte_position=byte_position,
+                     bit_position=bit_position, data_type=data_type,
+                     enum_map=enum or {})
+
+
+_RESOLVER = RoutineEntry(
+    name="RESOLVER_LEARNING", hex_id=0x0407, start=None, stop=None,
+    results=SubSpec(security_level=0, input={}, input_size=0, output_size=187,
+                    output={
+                        "RMSERROR": _fs(16, 184, data_type="int"),
+                        "LEARN_RESULT": _fs(3, 186, 0, "uint",
+                                            {"LEARN_SUCCESS": 0, "SPEED_RANGE": 4}),
+                        "RUNNING": _fs(1, 186, 4, "uint", {"FALSE": 0, "TRUE": 1}),
+                    }))
+_BOARD_SN = OdjEntry(
+    name="BOARD_SERIAL_NUMBER", hex_id=0xF013,
+    read=SubSpec(security_level=0, input={}, output_size=112, input_size=0,
+                 output={"BOARD_SERIAL_NUMBER": _fs(112, 0, data_type="ascii")}),
+    write=None)
+
+
+def _cfg(name="DI"):
+    return NodeConfig(name=name, request_can_id=0x1, response_can_id=0x2,
+                      security_algorithm="tesla_hash", security_buffer_size=16,
+                      security_kw={}, dids={"BOARD_SERIAL_NUMBER": _BOARD_SN},
+                      routines={"RESOLVER_LEARNING": _RESOLVER})
+
+
+def _resolver_bytes(flags):
+    return b"\x00" * 184 + struct.pack(">h", 0) + bytes([flags])
+
+
+class FakeSession:
+    """Records UDS calls; returns canned bytes for RESOLVER_LEARNING results."""
+
+    def __init__(self):
+        self.calls = []
+
+    def routine_control(self, rid, arg=b"", subtype=0x01):
+        self.calls.append(("routine_control", rid, bytes(arg), subtype))
+        if rid == 0x0407 and subtype == 0x03:
+            return _resolver_bytes(0x00)  # LEARN_SUCCESS, RUNNING=False
+        return b""
+
+    def read_did(self, did):
+        self.calls.append(("read_did", did))
+        if did == 0xF013:
+            return b"1234567890ABCD"
+        return b""
+
+    def write_did(self, did, data):
+        self.calls.append(("write_did", did, bytes(data)))
+
+    def diagnostic_session(self, mode):
+        self.calls.append(("diagnostic_session", mode))
+
+    def security_access(self, level_idx=0, seed_level=None):
+        self.calls.append(("security_access", level_idx, seed_level))
+
+    def ecu_reset(self, reset_type=0x01):
+        self.calls.append(("ecu_reset", reset_type))
+
+    def ecu_reset_no_wait(self, reset_type=0x01):
+        self.calls.append(("ecu_reset_no_wait", reset_type))
+
+    def clear_dtc(self, group=0xFFFFFF):
+        self.calls.append(("clear_dtc", group))
+
+    def read_dtcs(self, status_mask=0xFF):
+        self.calls.append(("read_dtcs", status_mask))
+        return {0x111111: 0x08}
+
+    def start_tester_present(self):
+        self.calls.append(("start_tester_present",))
+
+    def stop_tester_present(self):
+        self.calls.append(("stop_tester_present",))
+
+    def __exit__(self, *_):
+        pass
+
+
+# ---------------------------------------------------------------------------
+# _UdsAdapter — raw payloads onto UdsSession
+# ---------------------------------------------------------------------------
+
+class TestUdsAdapter:
+    def test_routine_control_hex_and_subtype(self):
+        s = FakeSession()
+        _UdsAdapter(s).routine_control("0xf00a", "00640052", "START_ROUTINE")
+        assert s.calls[0] == ("routine_control", 0xF00A, bytes.fromhex("00640052"), 0x01)
+
+    def test_read_write_data(self):
+        s = FakeSession()
+        a = _UdsAdapter(s)
+        a.read_data("0xf013")
+        a.write_data("0xf01c", "04")
+        assert ("read_did", 0xF013) in s.calls
+        assert ("write_did", 0xF01C, b"\x04") in s.calls
+
+    def test_security_access_level(self):
+        s = FakeSession()
+        _UdsAdapter(s).security_access("LEVEL_5")
+        assert s.calls[0] == ("security_access", 0, 5)
+
+    def test_diagnostic_session_extended(self):
+        s = FakeSession()
+        _UdsAdapter(s).diagnostic_session("EXTENDED_DIAGNOSTIC_SESSION")
+        assert s.calls[0] == ("diagnostic_session", 0x03)
+
+    def test_ecu_reset_response_required_toggles_no_wait(self):
+        s = FakeSession()
+        a = _UdsAdapter(s)
+        a.ecu_reset("HARD_RESET", True)
+        a.ecu_reset("HARD_RESET", False)
+        assert ("ecu_reset", 0x01) in s.calls
+        assert ("ecu_reset_no_wait", 0x01) in s.calls
+
+    def test_clear_dtcs_named_mask_falls_back_to_clear_all(self):
+        s = FakeSession()
+        _UdsAdapter(s).clear_dtcs("TestFailed")
+        assert s.calls[0] == ("clear_dtc", 0xFFFFFF)
+
+
+# ---------------------------------------------------------------------------
+# _OdxAdapter — named params via the ODJ codec
+# ---------------------------------------------------------------------------
+
+class TestOdxAdapter:
+    def test_start_and_wait_parses_results(self):
+        s = FakeSession()
+        out = _OdxAdapter(s, _cfg()).start_and_wait(
+            "RESOLVER_LEARNING", "RUNNING", [True], 1, time_scale=0.0)
+        assert out["LEARN_RESULT"] == "LEARN_SUCCESS"
+        assert out["RUNNING"] is False
+        # started (subtype 01) then polled results (subtype 03)
+        subtypes = [c[3] for c in s.calls if c[0] == "routine_control"]
+        assert subtypes[0] == 0x01 and 0x03 in subtypes
+
+    def test_read_data_decodes_ascii_did(self):
+        s = FakeSession()
+        out = _OdxAdapter(s, _cfg()).read_data("BOARD_SERIAL_NUMBER")
+        assert out["BOARD_SERIAL_NUMBER"] == "1234567890ABCD"
+
+    def test_get_value_parsed_vs_raw(self):
+        a = _OdxAdapter(FakeSession(), _cfg())
+        assert a.get_value("RESOLVER_LEARNING", "LEARN_RESULT", 4, parsed=True) == "SPEED_RANGE"
+        assert a.get_value("RESOLVER_LEARNING", "LEARN_RESULT", 4, parsed=False) == 4
+
+    def test_security_gated_routine_authenticates_first(self):
+        # A routine whose ODJ subspec declares a security level must trigger a
+        # programming-session SecurityAccess(seed_level) BEFORE the routine goes out
+        # (Tesla's odx layer does this from the ODJ; without it the ECU NRCs 0x33).
+        # Mirrors PMR CAN_COMM_SELF_TEST (0x3FD, level 5).
+        s = FakeSession()
+        gated = RoutineEntry(
+            name="CAN_COMM_SELF_TEST", hex_id=0x03FD, stop=None,
+            start=SubSpec(security_level=5, input={}, output={},
+                          input_size=0, output_size=0),
+            results=SubSpec(security_level=5, input={}, output={"OK": _fs(1, 0)},
+                            input_size=0, output_size=1))
+        cfg = NodeConfig(name="PMR", request_can_id=1, response_can_id=2,
+                         security_algorithm="tesla_hash", security_buffer_size=16,
+                         security_kw={}, routines={"CAN_COMM_SELF_TEST": gated})
+        _OdxAdapter(s, cfg).start_and_wait(
+            "CAN_COMM_SELF_TEST", None, [], 1, time_scale=0.0)
+        assert ("diagnostic_session", 0x03) in s.calls   # extended diagnostic session
+        assert ("security_access", 0, 5) in s.calls      # seed_level from the ODJ
+        kinds = [c[0] for c in s.calls]
+        assert kinds.index("security_access") < kinds.index("routine_control")
+
+    def test_unsecured_routine_skips_auth(self):
+        # A level-0 routine (RESOLVER_LEARNING here) must NOT enter a session or auth.
+        s = FakeSession()
+        _OdxAdapter(s, _cfg()).start_and_wait(
+            "RESOLVER_LEARNING", "RUNNING", [True], 1, time_scale=0.0)
+        assert not any(c[0] in ("diagnostic_session", "security_access") for c in s.calls)
+
+
+# ---------------------------------------------------------------------------
+# Engine handlers end-to-end (mini-graphs through a BenchBackend + fake sessions)
+# ---------------------------------------------------------------------------
+
+def _bench(**nodes):
+    """A BenchBackend with pre-seeded (cfg, FakeSession) per node — no real bus."""
+    bb = BenchBackend("chan")
+    sessions = {}
+    for node, sess in nodes.items():
+        bb._nodes[node.upper()] = (_cfg(node), sess)
+        sessions[node] = sess
+    return bb, sessions
+
+
+def lit(v):
+    return {"value": v}
+
+
+def conn(t):
+    return {"connection": t}
+
+
+class TestEngineHandlers:
+    def test_uds_ecu_reset(self):
+        sess = FakeSession()
+        bb, _ = _bench(RCM=sess)
+        eng = Engine(bb, Path("."), time_scale=1.0)
+        graph = {
+            "enter": {"type": "networks.Enter", "start": conn("reset.run")},
+            "reset": {"type": "uds.UdsEcuReset", "node_name": lit("RCM"),
+                      "reset_type": lit("HARD_RESET"), "response_required": lit(True),
+                      "done": conn("exit.exit")},
+            "exit": {"type": "networks.Exit", "exit_code": lit(0)},
+        }
+        assert eng.run_graph(graph, {}).exit_code == 0
+        assert ("ecu_reset", 0x01) in sess.calls
+
+    def test_odx_start_and_wait_results_into_metric(self):
+        sess = FakeSession()
+        bb, _ = _bench(DI=sess)
+        eng = Engine(bb, Path("."), time_scale=1.0)
+        graph = {
+            "enter": {"type": "networks.Enter", "start": conn("saw.run")},
+            "saw": {"type": "odx.OdxStartAndWaitResults", "node_name": lit("DI"),
+                    "routine_name": lit("RESOLVER_LEARNING"),
+                    "status_parameter": lit("RUNNING"),
+                    "in_progress_statuses": lit([True]), "timeout": lit(1),
+                    "done": conn("cap.capture")},
+            "cap": {"type": "reporting.CaptureMetric", "metric_name": lit("res"),
+                    "value": conn("saw.results"), "result_code": lit(0),
+                    "done": conn("exit.exit")},
+            "exit": {"type": "networks.Exit", "exit_code": lit(0)},
+        }
+        res = eng.run_graph(graph, {})
+        assert res.metrics[0]["value"]["LEARN_RESULT"] == "LEARN_SUCCESS"
+
+    def test_esp_is_stubbed(self):
+        # ESP has no session; uds('ESP') must not touch _nodes / raise.
+        bb = BenchBackend("chan")
+        assert isinstance(bb.uds("ESP"), odin_runner._StubUds)
+        bb.uds("ESP").ecu_reset("HARD_RESET", True)  # no-op, no crash
+
+
+class _FakeCanDb:
+    def decode_frame(self, arb_id, data):
+        if arb_id == 0x100:
+            return [{"signal": "SIG_A", "value": 42}, {"signal": "SIG_B", "value": 7}]
+        return []
+
+
+class TestLiveCanCache:
+    def test_rx_cache_decodes_into_signals(self):
+        cache = _CanRxCache(_FakeCanDb())
+        cache.on_message_received(
+            can.Message(arbitration_id=0x100, data=b"\x00", is_extended_id=False))
+        assert cache.get("SIG_A") == 42
+        assert cache.get("SIG_B") == 7
+        assert cache.get("UNSEEN") is None
+
+    def test_rx_cache_ignores_error_and_unknown_frames(self):
+        cache = _CanRxCache(_FakeCanDb())
+        cache.on_message_received(
+            can.Message(arbitration_id=0x999, data=b"\x00", is_extended_id=False))
+        assert cache.get("SIG_A") is None
+
+
+class TestProtoReadFile:
+    def test_reads_from_firmware_dump(self, tmp_path):
+        (tmp_path / "opt").mkdir()
+        (tmp_path / "opt" / "VERSION").write_text("VERSION 1.2\n")
+        bb = BenchBackend("chan", firmware_root=tmp_path)
+        eng = Engine(bb, Path("."), time_scale=1.0)
+        graph = {
+            "enter": {"type": "networks.Enter", "start": conn("rf.run")},
+            "rf": {"type": "proto.ReadFile", "filepath": lit("/opt/VERSION"),
+                   "mode": lit("r"), "done": conn("cap.capture")},
+            "cap": {"type": "reporting.CaptureMetric", "metric_name": lit("v"),
+                    "value": conn("rf.contents"), "result_code": lit(0),
+                    "done": conn("exit.exit")},
+            "exit": {"type": "networks.Exit", "exit_code": lit(0)},
+        }
+        assert eng.run_graph(graph, {}).metrics[0]["value"] == "VERSION 1.2\n"
+
+
+class TestReadDtcs:
+    def test_udssession_parses_dtc_response(self):
+        # Real UdsSession.read_dtcs parse, bypassing __init__ (no bus needed).
+        sess = UdsSession.__new__(UdsSession)
+        sess._send_raw = lambda payload, **k: [
+            0x59, 0x02, 0xFF, 0x12, 0x34, 0x56, 0x08, 0xAB, 0xCD, 0xEF, 0x2F]
+        assert sess.read_dtcs(0xFF) == {0x123456: 0x08, 0xABCDEF: 0x2F}
+
+    def test_udssession_empty_when_healthy(self):
+        sess = UdsSession.__new__(UdsSession)
+        sess._send_raw = lambda payload, **k: [0x59, 0x02, 0xFF]  # no DTCs
+        assert sess.read_dtcs() == {}
+
+    def test_engine_read_dtcs_handler(self):
+        sess = FakeSession()
+        bb, _ = _bench(RCM=sess)
+        eng = Engine(bb, Path("."), time_scale=1.0)
+        graph = {
+            "enter": {"type": "networks.Enter", "start": conn("rd.run")},
+            "rd": {"type": "uds.UdsReadDtcs", "node_name": lit("RCM"),
+                   "dtc_mask": lit("0x1"), "done": conn("cap.capture")},
+            "cap": {"type": "reporting.CaptureMetric", "metric_name": lit("dtcs"),
+                    "value": conn("rd.dtcs"), "result_code": lit(0),
+                    "done": conn("exit.exit")},
+            "exit": {"type": "networks.Exit", "exit_code": lit(0)},
+        }
+        res = eng.run_graph(graph, {})
+        assert res.metrics[0]["value"] == {0x111111: 0x08}
+        assert ("read_dtcs", 0x1) in sess.calls   # mask '0x1' parsed to int 1
+
+
+class TestStoreOutputs:
+    def test_persists_outputs_keyed_by_board(self, tmp_path):
+        from uds_local.datastore import DataStore
+        ds = DataStore(tmp_path / "odin_data.json")
+        bb, _ = _bench(DIR=FakeSession())  # read_did(0xF013) -> b"1234567890ABCD"
+        bb._datastore = ds
+        bb.store_outputs({"data_out": {"UNIT_ODOMETER": {"DRIVE_UNIT_ODOMETER": 5},
+                                       "ANGLE_OFFSET": b"\xff\xff"}})
+        stored = DataStore(tmp_path / "odin_data.json").get("1234567890ABCD", "outputs")
+        assert stored["data_out"]["UNIT_ODOMETER"] == {"DRIVE_UNIT_ODOMETER": 5}
+        assert stored["data_out"]["ANGLE_OFFSET"] == "ffff"   # bytes -> hex
+
+    def test_noop_when_no_outputs_or_no_board(self, tmp_path):
+        from uds_local.datastore import DataStore
+        ds = DataStore(tmp_path / "odin_data.json")
+        bb, _ = _bench(DIR=FakeSession())
+        bb._datastore = ds
+        bb.store_outputs({})                 # nothing to store
+        assert ds.boards() == []
+        bb2 = BenchBackend("chan")           # no nodes opened -> no board id
+        bb2._datastore = ds
+        bb2.store_outputs({"x": 1})
+        assert ds.boards() == []
+
+    def test_mock_backend_store_outputs_is_noop(self):
+        odin_runner.MockBackend("success").store_outputs({"x": 1})  # no error, no-op
+
+
+class _BlSession(FakeSession):
+    """FakeSession + a recording wait_for_bootloader (which UdsSession has, but the
+    plain FakeSession doesn't)."""
+    def wait_for_bootloader(self, **_kw):
+        self.calls.append(("wait_for_bootloader",))
+
+
+class TestEnsureApplicationState:
+    def test_bootloader_resets_then_waits_and_tracks(self):
+        sess = _BlSession()
+        bb, _ = _bench(PMR=sess)
+        bb.ensure_application_state("PMR", "BOOTLOADER")
+        assert ("ecu_reset_no_wait", 0x01) in sess.calls
+        assert ("wait_for_bootloader",) in sess.calls   # same handover as the flasher
+        assert "PMR" in bb._bootloader
+
+    def test_idempotent_bootloader(self):
+        sess = _BlSession()
+        bb, _ = _bench(PMR=sess)
+        bb.ensure_application_state("PMR", "BOOTLOADER")
+        sess.calls.clear()
+        bb.ensure_application_state("PMR", "BOOTLOADER")   # already in BL -> no reset
+        assert sess.calls == []
+
+    def test_application_resets_back_without_wait(self):
+        sess = _BlSession()
+        bb, _ = _bench(PMR=sess)
+        bb.ensure_application_state("PMR", "BOOTLOADER")
+        sess.calls.clear()
+        bb.ensure_application_state("PMR", "APPLICATION")
+        assert ("ecu_reset_no_wait", 0x01) in sess.calls
+        assert not any(c[0] == "wait_for_bootloader" for c in sess.calls)
+        assert "PMR" not in bb._bootloader
+
+    def test_none_and_already_app_are_noops(self):
+        sess = _BlSession()
+        bb, _ = _bench(PMR=sess)
+        bb.ensure_application_state("PMR", None)             # no state -> no-op
+        bb.ensure_application_state("PMR", "APPLICATION")    # already app (untracked)
+        assert not any(c[0] in ("ecu_reset_no_wait", "wait_for_bootloader")
+                       for c in sess.calls)

--- a/tests/test_odin_runner.py
+++ b/tests/test_odin_runner.py
@@ -1,0 +1,957 @@
+"""Tests for scripts/odin_runner.py -- the ODIN node-graph interpreter.
+
+Self-contained: every graph here is synthetic (built in-code or written to a
+tmp bundle), so nothing depends on Tesla's ODIN bundle. Covers the keystone
+(referenced-subnetwork I/O + the slots./outputs./signals. connection grammar)
+and the Step-2 pure-logic + iteration handler batch.
+"""
+import base64
+from pathlib import Path
+
+import odin_runner
+import pytest
+from odin_runner import Backend, Engine, Frame, MockBackend
+
+
+def _engine(bundle="."):
+    return Engine(MockBackend("success"), Path(bundle))
+
+
+def lit(v):
+    """A literal data field: {'value': v}."""
+    return {"value": v}
+
+
+def conn(target):
+    """A connection field: {'connection': 'node.port'}."""
+    return {"connection": target}
+
+
+def pull(node, extra=None, port="out"):
+    """Build a one-node graph and pull the node's data handler."""
+    graph = {"n": node}
+    if extra:
+        graph.update(extra)
+    e = _engine()
+    return e._pull(Frame(graph=graph, inputs={}, depth=0), conn(f"n.{port}"))
+
+
+def run(graph, inputs=None):
+    return _engine().run_graph(graph, inputs or {})
+
+
+# ---------------------------------------------------------------------------
+# Connection parser: node names never contain dots, so split on the FIRST dot.
+# ---------------------------------------------------------------------------
+
+class TestConnectionParser:
+    def test_two_dot_data_path_parses_node_then_portpath(self):
+        # A 'sub.outputs.exit_code' pull must resolve node 'sub', port 'outputs.exit_code'.
+        graph = {
+            "sub": {"type": "networks.ReferencedSubnetwork", "basename": "x",
+                    "outputs": {"exit_code": {"index": 0}}},
+        }
+        e = _engine()
+        frame = Frame(graph=graph, inputs={}, depth=0)
+        frame.scratch["sub"] = odin_runner.RunResult(3, [], {})
+        assert e._pull(frame, conn("sub.outputs.exit_code")) == 3
+
+
+# ---------------------------------------------------------------------------
+# Keystone: referenced subnetworks
+# ---------------------------------------------------------------------------
+
+_CHILD = '''
+network = {
+    "enter": {"type": "networks.Enter", "start": {"connection": "setout.set"}},
+    "n": {"type": "networks.Input", "default": {"value": 0}},
+    "mul": {"type": "math.Multiply",
+            "a": {"connection": "n.value"}, "b": {"value": 2}},
+    "setout": {"type": "networks.SetOutput", "key": "doubled",
+               "value": {"connection": "mul.product"},
+               "finished": {"connection": "exit.exit"}},
+    "exit": {"type": "networks.Exit", "exit_code": {"connection": "n.value"}},
+}
+'''
+
+_BARE_TASK = '''
+network = {
+    "task": {"type": "networks.RunReferencedSubnetwork", "basename": "child",
+             "inputs": {"n": {"value": 5}},
+             "outputs": {"exit_code": {"index": 0}, "doubled": {"index": 1}}},
+    "info": {"type": "comments.TaskInfo", "title": {"value": "t"}},
+}
+'''
+
+_WIRED = '''
+network = {
+    "enter": {"type": "networks.Enter", "start": {"connection": "sub.slots.enter"}},
+    "sub": {"type": "networks.ReferencedSubnetwork", "basename": "child",
+            "inputs": {"n": {"value": 7}},
+            "outputs": {"exit_code": {"index": 0}},
+            "slots": {"enter": {"index": 0}},
+            "signals": {"exit": {"index": 0, "connection": "cap.capture"}}},
+    "cap": {"type": "reporting.CaptureMetric", "metric_name": {"value": "code"},
+            "value": {"connection": "sub.outputs.exit_code"},
+            "result_code": {"value": 0}, "done": {"connection": "exit.exit"}},
+    "exit": {"type": "networks.Exit", "exit_code": {"value": 0}},
+}
+'''
+
+
+def _bundle(tmp_path, **graphs):
+    for stem, src in graphs.items():
+        (tmp_path / f"{stem}.py").write_text(src, encoding="utf-8")
+    return tmp_path
+
+
+class TestReferencedSubnetwork:
+    def test_bare_task_wrapper_resolves_inputs_and_outputs(self, tmp_path):
+        _bundle(tmp_path, child=_CHILD, parent=_BARE_TASK)
+        eng = Engine(MockBackend("success"), tmp_path)
+        res = eng.run_procedure("parent")
+        assert res.exit_code == 5           # child exits with exit_code = n
+        assert res.outputs["doubled"] == 10  # SetOutput wrote n*2
+
+    def test_inline_subnetwork_slots_signals_outputs(self, tmp_path):
+        _bundle(tmp_path, child=_CHILD, parent=_WIRED)
+        eng = Engine(MockBackend("success"), tmp_path)
+        res = eng.run_procedure("parent")
+        # signals.exit fired cap, which read sub.outputs.exit_code (=7) into a metric
+        assert res.exit_code == 0
+        assert [m["value"] for m in res.metrics] == [7]
+
+    def test_child_metrics_bubble_up(self, tmp_path):
+        child = '''
+network = {
+    "enter": {"type": "networks.Enter", "start": {"connection": "cap.capture"}},
+    "cap": {"type": "reporting.CaptureMetric", "metric_name": {"value": "inner"},
+            "value": {"value": 42}, "result_code": {"value": 0},
+            "done": {"connection": "exit.exit"}},
+    "exit": {"type": "networks.Exit", "exit_code": {"value": 0}},
+}
+'''
+        _bundle(tmp_path, child=child, parent=_BARE_TASK)
+        eng = Engine(MockBackend("success"), tmp_path)
+        res = eng.run_procedure("parent")
+        assert any(m["metric"] == "inner" and m["value"] == 42 for m in res.metrics)
+
+    def test_none_input_binding_uses_child_default(self, tmp_path):
+        # Binding a child input to None must fall back to the child's Input default,
+        # not None (ODIN: None == unset). Regression for WRITE_DRIVE_TYPE's
+        # pmr_power_ecu (default 'VCLEFT') being None'd out by the task binding.
+        child = '''
+network = {
+    "enter": {"type": "networks.Enter", "start": {"connection": "cap.capture"}},
+    "inp": {"type": "networks.Input", "default": {"value": "VCLEFT"}},
+    "cap": {"type": "reporting.CaptureMetric", "metric_name": {"value": "got"},
+            "value": {"connection": "inp.value"}, "result_code": {"value": 0},
+            "done": {"connection": "exit.exit"}},
+    "exit": {"type": "networks.Exit", "exit_code": {"value": 0}},
+}
+'''
+        parent = '''
+network = {
+    "task": {"type": "networks.RunReferencedSubnetwork", "basename": "child",
+             "inputs": {"inp": {"value": None}}},
+    "info": {"type": "comments.TaskInfo", "title": {"value": "t"}},
+}
+'''
+        _bundle(tmp_path, child=child, parent=parent)
+        res = Engine(MockBackend("success"), tmp_path).run_procedure("parent")
+        assert res.metrics[0]["value"] == "VCLEFT"   # default, not None
+
+
+# ---------------------------------------------------------------------------
+# Regression: the two bugs fixed alongside the batch
+# ---------------------------------------------------------------------------
+
+class TestCompareOperator:
+    def test_default_operator_is_equality(self):
+        assert pull({"type": "logic.Compare", "a": lit(5), "b": lit(5)}) is True
+        assert pull({"type": "logic.Compare", "a": lit(5), "b": lit(6)}) is False
+
+    def test_not_equal(self):
+        node = {"type": "logic.Compare", "a": lit(5), "b": lit(6), "operator": lit(1)}
+        assert pull(node) is True
+
+    def test_less_than(self):
+        node = {"type": "logic.Compare", "a": lit(3), "b": lit(5), "operator": lit(2)}
+        assert pull(node) is True
+        node["a"] = lit(9)
+        assert pull(node) is False
+
+
+class TestGetItemListIndexing:
+    def test_list_index(self):
+        node = {"type": "collections.GetItem", "data": lit([10, 20, 30]), "key": lit(1)}
+        assert pull(node) == 20
+
+    def test_list_out_of_range_returns_default(self):
+        node = {"type": "collections.GetItem", "data": lit([10]), "key": lit(9),
+                "default": lit("d")}
+        assert pull(node) == "d"
+
+    def test_dict_still_works(self):
+        node = {"type": "collections.GetItem", "data": lit({"k": 1}), "key": lit("k")}
+        assert pull(node) == 1
+
+
+# ---------------------------------------------------------------------------
+# logic
+# ---------------------------------------------------------------------------
+
+class TestLogic:
+    def test_is_in(self):
+        assert pull({"type": "logic.IsIn", "a": lit("x"), "b": lit(["x", "y"])}) is True
+        assert pull({"type": "logic.IsIn", "a": lit("z"), "b": lit(["x"])}) is False
+        assert pull({"type": "logic.IsIn", "a": lit("z"), "b": lit(None)}) is False
+
+    def test_is_not_in(self):
+        assert pull({"type": "logic.IsNotIn", "a": lit("z"), "b": lit(["x"])}) is True
+
+    def test_is_empty(self):
+        assert pull({"type": "logic.IsEmpty", "a": lit([])}) is True
+        assert pull({"type": "logic.IsEmpty", "a": lit(None)}) is True
+        assert pull({"type": "logic.IsEmpty", "a": lit("x")}) is False
+
+    def test_or_and_not(self):
+        assert pull({"type": "logic.Or", "a": lit(False), "b": lit(3)}) == 3
+        assert pull({"type": "logic.And", "a": lit(True), "b": lit(0)}) == 0
+        assert pull({"type": "logic.Not", "a": lit(0)}) is True
+
+    def test_is_none_nonzero(self):
+        assert pull({"type": "logic.IsNone", "a": lit(None)}) is True
+        assert pull({"type": "logic.IsNone", "a": lit(0)}) is False
+        assert pull({"type": "logic.IsNonZero", "a": lit(0)}) is False
+        assert pull({"type": "logic.IsNonZero", "a": lit(b"\x01")}) is True
+
+    def test_between(self):
+        node = {"type": "logic.Between", "a": lit(5), "low": lit(1), "high": lit(10)}
+        assert pull(node) is True
+        node["a"] = lit(11)
+        assert pull(node) is False
+
+    def test_less_than(self):
+        assert pull({"type": "logic.LessThan", "a": lit(1), "b": lit(2)}) is True
+
+    def test_multi_and_or(self):
+        inputs = {"x": {"index": 0, "value": True}, "y": {"index": 1, "value": False}}
+        assert pull({"type": "logic.MultiAndOr", "operator": lit("and"),
+                     "inputs": inputs}) is False
+        assert pull({"type": "logic.MultiAndOr", "operator": lit("or"),
+                     "inputs": inputs}) is True
+
+
+# ---------------------------------------------------------------------------
+# dicts / collections / lists / math
+# ---------------------------------------------------------------------------
+
+class TestDictsCollectionsLists:
+    def test_set_item_immutable(self):
+        base = {"a": 1}
+        out = pull({"type": "dicts.SetItem", "data": lit(base),
+                    "key": lit("b"), "value": lit(2)})
+        assert out == {"a": 1, "b": 2}
+        assert base == {"a": 1}  # original untouched
+
+    def test_set_item_without_data(self):
+        out = pull({"type": "dicts.SetItem", "key": lit("k"), "value": lit(9)})
+        assert out == {"k": 9}
+
+    def test_keys_values_merge_haskey(self):
+        d = lit({"a": 1, "b": 2})
+        assert pull({"type": "dicts.Keys", "data": d}) == ["a", "b"]
+        assert pull({"type": "dicts.Values", "data": d}) == [1, 2]
+        assert pull({"type": "dicts.Merge", "a": lit({"a": 1}), "b": lit({"b": 2})}) \
+            == {"a": 1, "b": 2}
+        assert pull({"type": "dicts.HasKey", "data": d, "key": lit("a")}) is True
+        assert pull({"type": "dicts.HasKey", "data": d, "key": lit("z")}) is False
+
+    def test_len_sort(self):
+        assert pull({"type": "collections.Len", "data": lit([1, 2, 3])}) == 3
+        assert pull({"type": "collections.Len", "data": lit(None)}) == 0
+        assert pull({"type": "collections.Sort", "data": lit([3, 1, 2])}) == [1, 2, 3]
+
+    def test_append_extend_any_splice(self):
+        assert pull({"type": "lists.Append", "items": lit([1]), "value": lit(2)}) == [1, 2]
+        assert pull({"type": "lists.Append", "value": lit("x")}) == ["x"]
+        assert pull({"type": "lists.Extend", "a": lit([1]), "b": lit([2, 3])}) == [1, 2, 3]
+        assert pull({"type": "lists.Any", "items": lit([0, "", 5])}) is True
+        assert pull({"type": "lists.Any", "items": lit([0, ""])}) is False
+        assert pull({"type": "lists.Splice", "items": lit([1, 2, 3, 4]),
+                     "start": lit(1), "end": lit(3)}) == [2, 3]
+
+    def test_math(self):
+        assert pull({"type": "math.Add", "a": lit(2), "b": lit(3)}) == 5
+        assert pull({"type": "math.Subtract", "a": lit(5), "b": lit(2)}) == 3
+        assert pull({"type": "math.Multiply", "a": lit(4), "b": lit(3)}) == 12
+        assert pull({"type": "math.Divide", "a": lit(9), "b": lit(3)}) == 3
+        assert pull({"type": "math.Mod", "x": lit(7), "divisor": lit(3)}) == 1
+
+
+# ---------------------------------------------------------------------------
+# strings / bytes / json / regex / sets / misc / types
+# ---------------------------------------------------------------------------
+
+class TestStringsBytesMisc:
+    def test_format(self):
+        node = {"type": "strings.Format", "text": lit("{a}/{b}"),
+                "options": lit({"a": "x", "b": "y"})}
+        assert pull(node) == "x/y"
+
+    def test_split_join(self):
+        assert pull({"type": "strings.Split", "text": lit("a-b-c"),
+                     "separator": lit("-")}) == ["a", "b", "c"]
+        assert pull({"type": "strings.Join", "items": lit(["a", "b"]),
+                     "joiner": lit(",")}) == "a,b"
+
+    def test_substring_strip(self):
+        assert pull({"type": "strings.Substring", "string": lit("abcdef"),
+                     "start": lit(1), "end": lit(3)}) == "bc"
+        assert pull({"type": "strings.Rstrip", "str": lit("hi \n")}) == "hi"
+        assert pull({"type": "strings.Strip", "str": lit("  hi  ")}) == "hi"
+        assert pull({"type": "strings.Splitlines", "text": lit("a\nb")}) == ["a", "b"]
+
+    def test_case(self):
+        assert pull({"type": "strings.Case", "text": lit("Ab"), "case": lit(0)}) == "ab"
+        assert pull({"type": "strings.Case", "text": lit("Ab"), "case": lit(1)}) == "AB"
+
+    def test_bytes_append_encode_decode(self):
+        assert pull({"type": "bytes.EncodeToBytes", "utf8_chars": lit("AB")}) == b"AB"
+        assert pull({"type": "bytes.DecodeToString", "value": lit(b"AB")}) == "AB"
+
+    def test_json_regex_sets(self):
+        assert pull({"type": "json.Dumps", "json": lit({"a": 1})}) == '{"a": 1}'
+        assert pull({"type": "json.Loads", "string": lit('{"a": 1}')}) == {"a": 1}
+        assert pull({"type": "regex.Findall", "pattern": lit(r"\d+"),
+                     "data": lit("a1b22")}) == ["1", "22"]
+        assert set(pull({"type": "sets.Intersection", "a": lit([1, 2, 3]),
+                         "b": lit([2, 3, 4])})) == {2, 3}
+        assert set(pull({"type": "sets.Difference", "a": lit([1, 2, 3]),
+                         "b": lit([2, 3])})) == {1}
+
+    def test_sanitize_string(self):
+        ok = {"type": "misc.SanitizeString", "input_text": lit("abc123"),
+              "digits": lit(True), "ascii_letters": lit(True)}
+        assert pull(ok) == "abc123"
+        bad = {"type": "misc.SanitizeString", "input_text": lit("a b"),
+               "ascii_letters": lit(True), "value_error_message": lit("nope")}
+        with pytest.raises(ValueError, match="nope"):
+            pull(bad)
+
+    def test_variant_to_number(self):
+        assert pull({"type": "types.VariantToNumber", "value": lit("42")}) == 42
+        assert pull({"type": "types.VariantToNumber", "value": lit("3.5")}) == 3.5
+
+
+# ---------------------------------------------------------------------------
+# control: data ternary + iteration (run whole mini-graphs)
+# ---------------------------------------------------------------------------
+
+def _cap(metric, value, done=None):
+    node = {"type": "reporting.CaptureMetric", "metric_name": lit(metric),
+            "value": value, "result_code": lit(0)}
+    if done:
+        node["done"] = done
+    return node
+
+
+class TestControlSwitch:
+    def test_data_ternary(self):
+        node = {"type": "control.Switch", "expr": lit(True),
+                "if_true": lit("T"), "if_false": lit("F")}
+        assert pull(node) == "T"
+        node["expr"] = lit(False)
+        assert pull(node) == "F"
+
+
+class TestIteration:
+    def test_for_each_binds_item_per_iteration(self):
+        graph = {
+            "enter": {"type": "networks.Enter", "start": conn("fe.run")},
+            "fe": {"type": "control.ForEach", "items": lit([1, 2, 3]),
+                   "run_each": conn("cap.capture"), "done": conn("exit.exit")},
+            "cap": _cap("m", conn("fe.item")),
+            "exit": {"type": "networks.Exit", "exit_code": lit(0)},
+        }
+        res = run(graph)
+        assert res.exit_code == 0
+        assert [m["value"] for m in res.metrics] == [1, 2, 3]
+
+    def test_for_each_entry_binds_key_and_value(self):
+        graph = {
+            "enter": {"type": "networks.Enter", "start": conn("fee.run")},
+            "fee": {"type": "control.ForEachEntry", "data": lit({"a": 1, "b": 2}),
+                    "run_each": conn("cap.capture"), "done": conn("exit.exit")},
+            "cap": {"type": "reporting.CaptureMetric",
+                    "metric_name": conn("fee.key"), "value": conn("fee.value"),
+                    "result_code": lit(0)},
+            "exit": {"type": "networks.Exit", "exit_code": lit(0)},
+        }
+        res = run(graph)
+        got = {m["metric"]: m["value"] for m in res.metrics}
+        assert got == {"a": 1, "b": 2}
+
+    def test_for_loop_counts(self):
+        graph = {
+            "enter": {"type": "networks.Enter", "start": conn("fl.run")},
+            "fl": {"type": "control.ForLoop", "end": lit(3),
+                   "run_each": conn("cap.capture"), "done": conn("exit.exit")},
+            "cap": _cap("m", conn("fl.i")),
+            "exit": {"type": "networks.Exit", "exit_code": lit(0)},
+        }
+        res = run(graph)
+        assert [m["value"] for m in res.metrics] == [0, 1, 2]
+
+    def test_timeout_loop_condition_met_takes_passed(self):
+        graph = {
+            "enter": {"type": "networks.Enter", "start": conn("tl.run")},
+            "tl": {"type": "control.TimeoutLoop", "timeout": lit(0),
+                   "run_body": conn("noop.capture"), "condition": lit(True),
+                   "passed": conn("ok.exit"), "timed_out": conn("bad.exit")},
+            "noop": _cap("body", lit(1)),
+            "ok": {"type": "networks.Exit", "exit_code": lit(0)},
+            "bad": {"type": "networks.Exit", "exit_code": lit(1)},
+        }
+        assert run(graph).exit_code == 0
+
+    def test_timeout_loop_condition_false_times_out(self):
+        graph = {
+            "enter": {"type": "networks.Enter", "start": conn("tl.run")},
+            "tl": {"type": "control.TimeoutLoop", "timeout": lit(0),
+                   "run_body": conn("noop.capture"), "condition": lit(False),
+                   "passed": conn("ok.exit"), "timed_out": conn("bad.exit")},
+            "noop": _cap("body", lit(1)),
+            "ok": {"type": "networks.Exit", "exit_code": lit(0)},
+            "bad": {"type": "networks.Exit", "exit_code": lit(1)},
+        }
+        assert run(graph).exit_code == 1
+
+
+class TestCounter:
+    def test_counter_increments_on_each_fire(self):
+        # fire the counter from a ForLoop body 3x, then read its count into a metric.
+        graph = {
+            "enter": {"type": "networks.Enter", "start": conn("fl.run")},
+            "fl": {"type": "control.ForLoop", "end": lit(3),
+                   "run_each": conn("ctr.increment"), "done": conn("cap.capture")},
+            "ctr": {"type": "control.Counter", "updated": None},
+            "cap": _cap("count", conn("ctr.count"), done=conn("exit.exit")),
+            "exit": {"type": "networks.Exit", "exit_code": lit(0)},
+        }
+        res = run(graph)
+        assert [m["value"] for m in res.metrics] == [3]
+
+
+class TestTryExcept:
+    def test_exception_routes_to_except_body(self):
+        graph = {
+            "enter": {"type": "networks.Enter", "start": conn("te.run")},
+            "te": {"type": "control.TryExcept", "exception_class": lit("RuntimeError"),
+                   "try_body": conn("boom.capture"),
+                   "except_body": conn("caught.capture"),
+                   "finally_body": conn("exit.exit")},
+            "boom": _cap("boom", conn("div.result")),   # 1/0 raises inside the pull
+            "div": {"type": "math.Divide", "a": lit(1), "b": lit(0)},
+            "caught": _cap("caught", lit("ok")),
+            "exit": {"type": "networks.Exit", "exit_code": lit(0)},
+        }
+        res = run(graph)
+        assert [m["metric"] for m in res.metrics] == ["caught"]
+
+    def test_no_exception_runs_else_body(self):
+        graph = {
+            "enter": {"type": "networks.Enter", "start": conn("te.run")},
+            "te": {"type": "control.TryExcept", "exception_class": lit("RuntimeError"),
+                   "try_body": conn("ok.capture"), "else_body": conn("els.capture"),
+                   "except_body": conn("caught.capture"),
+                   "finally_body": conn("exit.exit")},
+            "ok": _cap("ok", lit(1)),
+            "els": _cap("else", lit(1)),
+            "caught": _cap("caught", lit(1)),
+            "exit": {"type": "networks.Exit", "exit_code": lit(0)},
+        }
+        metrics = [m["metric"] for m in run(graph).metrics]
+        assert metrics == ["ok", "else"]  # except_body never ran
+
+
+class TestVehicleControls:
+    def test_power_context_runs_body_then_done(self):
+        graph = {
+            "enter": {"type": "networks.Enter", "start": conn("pc.run")},
+            "pc": {"type": "vehiclecontrols.PowerContext", "power_state": lit("DRIVE"),
+                   "body": conn("body.capture"), "failure": conn("fail.capture"),
+                   "done": conn("exit.exit")},
+            "body": _cap("body", lit(1)),
+            "fail": _cap("failure", lit(1)),
+            "exit": {"type": "networks.Exit", "exit_code": lit(0)},
+        }
+        res = run(graph)
+        assert res.exit_code == 0
+        assert [m["metric"] for m in res.metrics] == ["body"]  # failure not fired
+
+    def test_ensure_states_fire_done(self):
+        for ntype, extra in (
+            ("vehiclecontrols.EnsureApplicationState",
+             {"node_name": lit("DI"), "application_state": lit("APPLICATION")}),
+            ("vehiclecontrols.EnsurePowerState", {"power_state": lit("OFF")}),
+            ("vehiclecontrols.McuScreenOn", {}),
+        ):
+            graph = {
+                "enter": {"type": "networks.Enter", "start": conn("n.run")},
+                "n": {"type": ntype, "done": conn("exit.exit"), **extra},
+                "exit": {"type": "networks.Exit", "exit_code": lit(0)},
+            }
+            assert run(graph).exit_code == 0, ntype
+
+
+class TestStep6Logic:
+    def test_from_inputs_is_ordered_list(self):
+        node = {"type": "dicts.FromInputs", "a": lit(1), "c": lit(3), "b": lit(2)}
+        assert pull(node) == [1, 2, 3]   # ordered by letter, not insertion
+
+    def test_base64(self):
+        enc = pull({"type": "bytes.Base64Encode", "value": lit(b"AB")})
+        assert enc == base64.b64encode(b"AB")
+        assert pull({"type": "bytes.Base64Decode", "value": lit(enc)}) == b"AB"
+
+    def test_random_bytes_length(self):
+        assert len(pull({"type": "bytes.RandomBytes", "n": lit(8)})) == 8
+
+    def test_bytes_to_int(self):
+        assert pull({"type": "can.BytesToInt", "bytes": lit(b"\x01\x00")}) == 256
+        assert pull({"type": "can.BytesToInt", "bytes": lit(5)}) == 5   # int passthrough
+
+    def test_messages_fire_done(self):
+        for ntype, extra in (
+            ("messages.ProgressUpdate", {"value": lit(50)}),
+            ("messages.StatusUpdate", {"status": lit("working")}),
+            ("messages.Listen", {"message_type": lit("stop_now")}),
+        ):
+            graph = {
+                "enter": {"type": "networks.Enter", "start": conn("n.run")},
+                "n": {"type": ntype, "done": conn("exit.exit"), **extra},
+                "exit": {"type": "networks.Exit", "exit_code": lit(0)},
+            }
+            assert run(graph).exit_code == 0, ntype
+
+
+class _CanBackend(Backend):
+    """can_read returns a constant, or pops successive values from a list."""
+
+    def __init__(self, values):
+        self._v = values
+
+    def can_read(self, signal, bus=None):
+        val = self._v.get(signal)
+        if isinstance(val, list):
+            return val.pop(0) if val else None
+        return val
+
+
+class TestLiveCan:
+    def test_signal_read(self):
+        graph = {
+            "enter": {"type": "networks.Enter", "start": conn("cap.capture")},
+            "cap": _cap("v", conn("csr.value"), done=conn("exit.exit")),
+            "csr": {"type": "can.CANSignalRead", "signal_name": lit("X"),
+                    "bus_name": lit("ETH")},
+            "exit": {"type": "networks.Exit", "exit_code": lit(0)},
+        }
+        eng = Engine(_CanBackend({"X": 42}), Path("."), time_scale=0.0)
+        assert eng.run_graph(graph, {}).metrics[0]["value"] == 42
+
+    def test_monitor_change_fires_value_changed(self):
+        graph = self._monitor_graph()
+        eng = Engine(_CanBackend({"X": [1, 2]}), Path("."), time_scale=0.0)
+        assert eng.run_graph(graph, {}).exit_code == 0   # value_changed -> exit 0
+
+    def test_monitor_no_change_times_out(self):
+        graph = self._monitor_graph()
+        eng = Engine(_CanBackend({"X": [1, 1]}), Path("."), time_scale=0.0)
+        assert eng.run_graph(graph, {}).exit_code == 1   # timed_out -> exit 1
+
+    @staticmethod
+    def _monitor_graph():
+        return {
+            "enter": {"type": "networks.Enter", "start": conn("mon.run")},
+            "mon": {"type": "can.CANSignalMonitor", "signal_name": lit("X"),
+                    "bus_name": lit("ETH"), "timeout": lit(0), "enabled": lit(True),
+                    "value_changed": conn("chg.exit"), "timed_out": conn("to.exit")},
+            "chg": {"type": "networks.Exit", "exit_code": lit(0)},
+            "to": {"type": "networks.Exit", "exit_code": lit(1)},
+        }
+
+
+# ---------------------------------------------------------------------------
+# Step 7: inline networks.Subnetwork (both entry styles) + de-prefix
+# ---------------------------------------------------------------------------
+
+class TestInlineSubnetwork:
+    def test_enter_exit_style_inputs_outputs_signal(self):
+        # An inline Enter/Exit subnet: inner connections carry the 'sub.' prefix,
+        # inputs bind from a parent node, outputs read via sub.outputs.<name>, and
+        # the parent continues via signals.exit after the child completes.
+        graph = {
+            "enter": {"type": "networks.Enter", "start": conn("sub.slots.enter")},
+            "seed": {"type": "constant.Constant", "value": lit(3)},
+            "sub": {
+                "type": "networks.Subnetwork",
+                "slots": {"enter": {"index": 0}},
+                "signals": {"exit": {"index": 0, "connection": "cap.capture"}},
+                "inputs": {"n": {"connection": "seed.out"}},
+                "outputs": {"exit_code": {"index": 0}, "tripled": {"index": 1}},
+                "enter": {"type": "networks.Enter",
+                          "start": {"connection": "sub.setout.set"}},
+                "n": {"type": "networks.Input", "default": {"value": 0}},
+                "mul": {"type": "math.Multiply", "a": {"connection": "sub.n.value"},
+                        "b": {"value": 3}},
+                "setout": {"type": "networks.SetOutput", "key": "tripled",
+                           "value": {"connection": "sub.mul.product"},
+                           "finished": {"connection": "sub.exit.exit"}},
+                "exit": {"type": "networks.Exit",
+                         "exit_code": {"connection": "sub.n.value"}},
+            },
+            "cap": _cap("t", conn("sub.outputs.tripled"), done=conn("exit.exit")),
+            "exit": {"type": "networks.Exit",
+                     "exit_code": conn("sub.outputs.exit_code")},
+        }
+        res = run(graph)
+        assert res.exit_code == 3                     # inner exit_code = n
+        assert [m["value"] for m in res.metrics] == [9]   # tripled = n*3
+
+    def test_slot_signal_style_runs_inner_and_fires_exit(self):
+        # An inline Slot/Signal subnet: networks.Slot is the entry relay, networks.Signal
+        # the exit relay. Inner metrics bubble up; the parent continues via signals.exit.
+        graph = {
+            "enter": {"type": "networks.Enter", "start": conn("sub.slots.enter")},
+            "sub": {
+                "type": "networks.Subnetwork",
+                "slots": {"enter": {"index": 0}},
+                "signals": {"exit": {"index": 0, "connection": "cap.capture"}},
+                "slot": {"type": "networks.Slot",
+                         "signal": {"connection": "sub.body.capture"}},
+                "body": {"type": "reporting.CaptureMetric",
+                         "metric_name": {"value": "inner"}, "value": {"value": 7},
+                         "result_code": {"value": 0},
+                         "done": {"connection": "sub.signal.emit"}},
+                "signal": {"type": "networks.Signal"},
+            },
+            "cap": _cap("outer", lit("ok"), done=conn("exit.exit")),
+            "exit": {"type": "networks.Exit", "exit_code": lit(0)},
+        }
+        res = run(graph)
+        assert res.exit_code == 0
+        assert [m["metric"] for m in res.metrics] == ["inner", "outer"]
+
+
+# ---------------------------------------------------------------------------
+# Step 7: control.Break / MultiSplit+MultiMerge / Merge
+# ---------------------------------------------------------------------------
+
+class TestControlFlowStep7:
+    def test_break_stops_the_enclosing_loop(self):
+        graph = {
+            "enter": {"type": "networks.Enter", "start": conn("fe.run")},
+            "fe": {"type": "control.ForEach", "items": lit([1, 2, 3, 4]),
+                   "run_each": conn("chk.run"), "done": conn("exit.exit")},
+            "chk": {"type": "control.IfThen", "expr": conn("eq.result"),
+                    "if_true": conn("brk.stop"), "if_false": conn("cap.capture")},
+            "eq": {"type": "logic.Compare", "a": conn("fe.item"), "b": lit(3)},
+            "brk": {"type": "control.Break"},
+            "cap": _cap("seen", conn("fe.item")),
+            "exit": {"type": "networks.Exit", "exit_code": lit(0)},
+        }
+        res = run(graph)
+        assert res.exit_code == 0
+        assert [m["value"] for m in res.metrics] == [1, 2]  # 3 breaks, 4 unseen
+
+    def test_multisplit_multimerge_join(self):
+        graph = {
+            "enter": {"type": "networks.Enter", "start": conn("ms.run")},
+            "ms": {"type": "control.MultiSplit", "branches": {
+                "A": {"index": 0, "connection": "capA.capture"},
+                "B": {"index": 1, "connection": "capB.capture"}}},
+            "capA": _cap("A", lit(1), done=conn("mm.dependencies.A")),
+            "capB": _cap("B", lit(1), done=conn("mm.dependencies.B")),
+            "mm": {"type": "control.MultiMerge",
+                   "dependencies": {"A": {"index": 0}, "B": {"index": 1}},
+                   "done": conn("final.capture")},
+            "final": _cap("joined", lit(1), done=conn("exit.exit")),
+            "exit": {"type": "networks.Exit", "exit_code": lit(0)},
+        }
+        res = run(graph)
+        assert res.exit_code == 0
+        assert [m["metric"] for m in res.metrics] == ["A", "B", "joined"]
+
+    def test_merge_continues_on_first_arrival(self):
+        graph = {
+            "enter": {"type": "networks.Enter", "start": conn("ift.run")},
+            "ift": {"type": "control.IfThen", "expr": lit(True),
+                    "if_true": conn("mg.first"), "if_false": conn("mg.second")},
+            "mg": {"type": "control.Merge", "done": conn("cap.capture")},
+            "cap": _cap("merged", lit(1), done=conn("exit.exit")),
+            "exit": {"type": "networks.Exit", "exit_code": lit(0)},
+        }
+        res = run(graph)
+        assert [m["metric"] for m in res.metrics] == ["merged"]
+
+
+# ---------------------------------------------------------------------------
+# Step 7: AppendOutput / ForAccumulate
+# ---------------------------------------------------------------------------
+
+class TestAccumulators:
+    def test_append_output_builds_a_list(self):
+        graph = {
+            "enter": {"type": "networks.Enter", "start": conn("fl.run")},
+            "fl": {"type": "control.ForLoop", "end": lit(3),
+                   "run_each": conn("ao.append"), "done": conn("exit.exit")},
+            "ao": {"type": "networks.AppendOutput", "key": "items",
+                   "value": conn("fl.i")},
+            "exit": {"type": "networks.Exit", "exit_code": lit(0)},
+        }
+        assert run(graph).outputs["items"] == [0, 1, 2]
+
+    def test_for_accumulate_collects_then_reads_results(self):
+        graph = {
+            "enter": {"type": "networks.Enter", "start": conn("fl.run")},
+            "fl": {"type": "control.ForLoop", "end": lit(3),
+                   "run_each": conn("fa.run"), "done": conn("cap.capture")},
+            "fa": {"type": "control.ForAccumulate", "value": conn("fl.i")},
+            "cap": _cap("acc", conn("fa.results"), done=conn("exit.exit")),
+            "exit": {"type": "networks.Exit", "exit_code": lit(0)},
+        }
+        assert run(graph).metrics[0]["value"] == [0, 1, 2]
+
+
+# ---------------------------------------------------------------------------
+# Step 7: pure-logic tail (DateTime / Uuid / SeriesSum / Abs / ActiveAlerts)
+# ---------------------------------------------------------------------------
+
+class TestLogicTail:
+    def test_datetime_is_iso_string(self):
+        v = pull({"type": "misc.DateTime"}, port="now")
+        assert isinstance(v, str) and "T" in v
+
+    def test_uuid_is_uuid_string(self):
+        v = pull({"type": "misc.Uuid"}, port="uuid")
+        assert isinstance(v, str) and len(v) == 36
+
+    def test_series_sum_and_abs(self):
+        assert pull({"type": "math.SeriesSum", "series": lit([1, 2, 3])},
+                    port="sum") == 6
+        assert pull({"type": "math.SeriesSum", "series": lit(None)}, port="sum") == 0
+        assert pull({"type": "math.Abs", "value": lit(-5)}, port="result") == 5
+
+    def test_active_alerts_default_empty(self):
+        assert pull({"type": "can.ActiveAlerts", "bus_name": lit("ETH")},
+                    port="alerts") == []
+
+
+# ---------------------------------------------------------------------------
+# Step 7: interop tail (CaptureConnectorInfoLookup / SaveAuthoredPopup /
+# messages.Send / OdxStartAndWaitResults_V2 / UdsIOControl)
+# ---------------------------------------------------------------------------
+
+class TestInteropTail:
+    def test_capture_connector_info_lookup_records_metric(self):
+        graph = {
+            "enter": {"type": "networks.Enter", "start": conn("cci.capture")},
+            "cci": {"type": "reporting.CaptureConnectorInfoLookup",
+                    "file_name": lit("tuner.json"), "exit_code": lit(0),
+                    "done": conn("exit.exit")},
+            "exit": {"type": "networks.Exit", "exit_code": lit(0)},
+        }
+        res = run(graph)
+        m = res.metrics[0]
+        assert m["metric"] == "ConnectorInfoLookup"
+        assert m["value"] == "tuner.json" and m["result_code"] == 0
+
+    def test_save_authored_popup_stores_and_reports_success(self):
+        graph = {
+            "enter": {"type": "networks.Enter", "start": conn("sp.save")},
+            "sp": {"type": "cid.SaveAuthoredPopup", "identifier": lit("id1"),
+                   "data": lit("blob"), "done": conn("cap.capture")},
+            "cap": _cap("ok", conn("sp.success"), done=conn("exit.exit")),
+            "exit": {"type": "networks.Exit", "exit_code": lit(0)},
+        }
+        backend = MockBackend("success")
+        res = Engine(backend, Path(".")).run_graph(graph, {})
+        assert res.metrics[0]["value"] is True
+        assert backend.cid_load("id1") == "blob"
+
+    def test_messages_send_fires_done(self):
+        graph = {
+            "enter": {"type": "networks.Enter", "start": conn("snd.send")},
+            "snd": {"type": "messages.Send", "payload": lit("X"),
+                    "done": conn("exit.exit")},
+            "exit": {"type": "networks.Exit", "exit_code": lit(0)},
+        }
+        assert run(graph).exit_code == 0
+
+    @staticmethod
+    def _v2_graph():
+        return {
+            "enter": {"type": "networks.Enter", "start": conn("v2.run")},
+            "v2": {"type": "odx.OdxStartAndWaitResults_V2", "node_name": lit("RADC"),
+                   "routine_name": lit("R"), "status_parameter": lit("ST"),
+                   "in_progress_statuses": lit(["BUSY"]), "max_runtime": lit(0),
+                   "success": conn("ok.exit"), "failed": conn("bad.exit")},
+            "ok": {"type": "networks.Exit", "exit_code": lit(0)},
+            "bad": {"type": "networks.Exit", "exit_code": lit(1)},
+        }
+
+    def test_odx_v2_success_when_status_leaves_in_progress(self):
+        assert Engine(_V2Backend("DONE"), Path(".")).run_graph(
+            self._v2_graph(), {}).exit_code == 0
+
+    def test_odx_v2_failed_when_still_in_progress(self):
+        assert Engine(_V2Backend("BUSY"), Path(".")).run_graph(
+            self._v2_graph(), {}).exit_code == 1
+
+    def test_uds_io_control_routes_to_backend(self):
+        backend = _IOBackend()
+        graph = {
+            "enter": {"type": "networks.Enter", "start": conn("io.run")},
+            "io": {"type": "uds.UdsIOControl", "node_name": lit("VCSEC"),
+                   "control_id": lit("0x382"), "control_type": lit("SHORT_TERM_ADJUST"),
+                   "input_payload": lit("0101"), "done": conn("cap.capture")},
+            "cap": _cap("iodata", conn("io.data"), done=conn("exit.exit")),
+            "exit": {"type": "networks.Exit", "exit_code": lit(0)},
+        }
+        res = Engine(backend, Path(".")).run_graph(graph, {})
+        assert backend.calls == [("VCSEC", "0x382", "SHORT_TERM_ADJUST", "0101")]
+        assert res.metrics[0]["value"] == b"\x01"
+
+
+class _V2Backend(Backend):
+    """odx.start_and_wait returns a fixed final status for the V2 branch test."""
+
+    def __init__(self, final_status):
+        self._final = final_status
+
+    def odx(self, node_name):
+        return self
+
+    def start_and_wait(self, routine, status_param, in_progress, timeout, **_kw):
+        return {status_param: self._final}
+
+
+class _IOBackend(Backend):
+    """Records uds.io_control calls and returns a canned response."""
+
+    def __init__(self):
+        self.calls = []
+
+    def uds(self, node_name):
+        outer = self
+
+        class _A:
+            def io_control(self, control_id, control_type=None, payload=None):
+                outer.calls.append((node_name, control_id, control_type, payload))
+                return b"\x01"
+
+        return _A()
+
+
+# ---------------------------------------------------------------------------
+# Step 7: scripts.RunScriptTest + DynamicallyReferencedSubnetwork (tmp bundle)
+# ---------------------------------------------------------------------------
+
+_SCRIPT = '''
+network = {
+    "enter": {"type": "networks.Enter", "start": {"connection": "cap.capture"}},
+    "cap": {"type": "reporting.CaptureMetric", "metric_name": {"value": "scripted"},
+            "value": {"value": 99}, "result_code": {"value": 0},
+            "done": {"connection": "exit.exit"}},
+    "exit": {"type": "networks.Exit", "exit_code": {"value": 0}},
+}
+'''
+
+_SCRIPT_TASK = '''
+network = {
+    "task": {"type": "scripts.RunScriptTest", "script_name": "myscript"},
+    "info": {"type": "comments.TaskInfo", "title": {"value": "t"}},
+}
+'''
+
+_DYN_TASK = '''
+network = {
+    "enter": {"type": "networks.Enter", "start": {"connection": "dyn.run"}},
+    "which": {"type": "constant.Constant", "value": {"value": "child"}},
+    "dyn": {"type": "networks.DynamicallyReferencedSubnetwork",
+            "name": {"connection": "which.out"},
+            "done": {"connection": "exit.exit"}},
+    "exit": {"type": "networks.Exit", "exit_code": {"value": 0}},
+}
+'''
+
+_DYN_CHILD = '''
+network = {
+    "enter": {"type": "networks.Enter", "start": {"connection": "cap.capture"}},
+    "cap": {"type": "reporting.CaptureMetric", "metric_name": {"value": "dynran"},
+            "value": {"value": 5}, "result_code": {"value": 0},
+            "done": {"connection": "exit.exit"}},
+    "exit": {"type": "networks.Exit", "exit_code": {"value": 0}},
+}
+'''
+
+
+class TestScriptAndDynamicSubnet:
+    def test_run_script_test_entry_runs_the_script_graph(self, tmp_path):
+        _bundle(tmp_path, myscript=_SCRIPT, parent=_SCRIPT_TASK)
+        res = Engine(MockBackend("success"), tmp_path).run_procedure("parent")
+        assert any(m["metric"] == "scripted" and m["value"] == 99
+                   for m in res.metrics)
+
+    def test_dynamic_subnetwork_resolves_basename_at_runtime(self, tmp_path):
+        _bundle(tmp_path, child=_DYN_CHILD, parent=_DYN_TASK)
+        res = Engine(MockBackend("success"), tmp_path).run_procedure("parent")
+        assert res.exit_code == 0
+        assert any(m["metric"] == "dynran" for m in res.metrics)
+
+
+# ---------------------------------------------------------------------------
+# Step 7 addendum: isotp.Send (raw ISO-TP transport via the py-uds stack)
+# ---------------------------------------------------------------------------
+
+class _IsotpBackend(Backend):
+    """Records isotp_send calls and returns a fixed success flag."""
+
+    def __init__(self, ok=True):
+        self.ok = ok
+        self.sent = []
+
+    def isotp_send(self, to_controller, from_controller, data, bus=None):
+        self.sent.append((to_controller, from_controller, data, bus))
+        return self.ok
+
+
+class TestIsotpSend:
+    @staticmethod
+    def _graph():
+        return {
+            "enter": {"type": "networks.Enter", "start": conn("snd.transmit")},
+            "snd": {"type": "isotp.Send", "to_controller": lit("0x480"),
+                    "from_controller": lit(953), "data": lit("dead"),
+                    "done": conn("cap.capture")},
+            "cap": _cap("ok", conn("snd.success"), done=conn("exit.exit")),
+            "exit": {"type": "networks.Exit", "exit_code": lit(0)},
+        }
+
+    def test_routes_ids_and_data_to_backend(self):
+        backend = _IsotpBackend(ok=True)
+        res = Engine(backend, Path(".")).run_graph(self._graph(), {})
+        # to_controller '0x480' is coerced to int; from_controller passed through.
+        assert backend.sent == [(0x480, 953, "dead", None)]
+        assert res.metrics[0]["value"] is True
+
+    def test_failure_is_reported_via_success_port(self):
+        backend = _IsotpBackend(ok=False)
+        res = Engine(backend, Path(".")).run_graph(self._graph(), {})
+        assert res.metrics[0]["value"] is False
+
+    def test_default_backend_reports_success(self):
+        assert Backend().isotp_send(0x480, 953, b"\x01") is True

--- a/tests/test_odin_service.py
+++ b/tests/test_odin_service.py
@@ -1,0 +1,410 @@
+"""Tests for scripts/odin_service.py -- the shared CLI/web core over the ODIN
+engine + coverage.
+
+Self-contained: every graph is synthetic, written into a tmp bundle laid out like
+the real one (Model3/tasks entries + Model3/lib children), so nothing depends on
+Tesla's ODIN bundle. Covers discovery (list_procedures: runnable vs blocked, both
+TaskInfo title shapes) and a streamed run (run_procedure: on_event trace/metric/
+done events + the RunResult-as-dict).
+"""
+from pathlib import Path
+
+import odin_runner
+import odin_service
+
+from uds_local.node_config import NodeConfig
+from uds_local.odj import FieldSpec, OdjEntry, SubSpec
+
+
+def _write(bundle: Path, relbase: str, src: str) -> None:
+    path = bundle / (relbase + ".py")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(src, encoding="utf-8")
+
+
+# A wired child graph using only handled node types (math.Multiply + SetOutput).
+_CHILD = '''
+network = {
+    "enter": {"type": "networks.Enter", "start": {"connection": "setout.set"}},
+    "n": {"type": "networks.Input", "default": {"value": 0}},
+    "mul": {"type": "math.Multiply", "a": {"connection": "n.value"}, "b": {"value": 2}},
+    "setout": {"type": "networks.SetOutput", "key": "doubled",
+               "value": {"connection": "mul.product"},
+               "finished": {"connection": "exit.exit"}},
+    "exit": {"type": "networks.Exit", "exit_code": {"value": 0}},
+}
+'''
+
+# Runnable entry: bare-task wrapper + a TaskInfo with the WRAPPED title shape
+# ({'value': ...}) plus valid_states / principals.
+_RUNNABLE = '''
+network = {
+    "task": {"type": "networks.RunReferencedSubnetwork", "basename": "Model3/lib/dbl",
+             "inputs": {"n": {"value": 5}},
+             "outputs": {"exit_code": {"index": 0}, "doubled": {"index": 1}}},
+    "info": {"type": "comments.TaskInfo", "title": {"value": "Double It"},
+             "valid_states": ["StandStill|Parked"], "principals": ["tbx-internal"]},
+}
+'''
+
+# Blocked entry: references an unhandled node type; TaskInfo uses the BARE title
+# shape (a plain string), matching the real bundle.
+_BLOCKED = '''
+network = {
+    "enter": {"type": "networks.Enter", "start": {"connection": "x.run"}},
+    "x": {"type": "custommod.CustomNode", "done": {"connection": "exit.exit"}},
+    "exit": {"type": "networks.Exit", "exit_code": {"value": 0}},
+    "info": {"type": "comments.TaskInfo", "title": "Blocked One"},
+}
+'''
+
+# Runnable entry with NO TaskInfo (metadata must degrade to None/empty).
+_NOINFO = '''
+network = {
+    "enter": {"type": "networks.Enter", "start": {"connection": "exit.exit"}},
+    "exit": {"type": "networks.Exit", "exit_code": {"value": 0}},
+}
+'''
+
+
+def _make_bundle(tmp_path: Path) -> Path:
+    _write(tmp_path, "Model3/lib/dbl", _CHILD)
+    _write(tmp_path, "Model3/tasks/RUNNABLE-TASK", _RUNNABLE)
+    _write(tmp_path, "Model3/tasks/BLOCKED-TASK", _BLOCKED)
+    _write(tmp_path, "Model3/tasks/NOINFO-TASK", _NOINFO)
+    return tmp_path
+
+
+class TestListProcedures:
+    def test_all_procs_annotated_with_runnable_and_metadata(self, tmp_path):
+        procs = odin_service.list_procedures(bundle=_make_bundle(tmp_path),
+                                             runnable_only=False)
+        by_name = {p["name"]: p for p in procs}
+        assert set(by_name) == {"RUNNABLE-TASK", "BLOCKED-TASK", "NOINFO-TASK"}
+
+        run = by_name["RUNNABLE-TASK"]
+        assert run["runnable"] is True
+        assert run["missing_types"] == []
+        assert run["basename"] == "Model3/tasks/RUNNABLE-TASK"
+        assert run["title"] == "Double It"                 # wrapped {'value': ...}
+        assert run["valid_states"] == ["StandStill|Parked"]
+        assert run["principals"] == ["tbx-internal"]
+
+    def test_blocked_proc_reports_missing_type_and_bare_title(self, tmp_path):
+        procs = odin_service.list_procedures(bundle=_make_bundle(tmp_path),
+                                             runnable_only=False)
+        blocked = next(p for p in procs if p["name"] == "BLOCKED-TASK")
+        assert blocked["runnable"] is False
+        assert "custommod.CustomNode" in blocked["missing_types"]
+        assert blocked["title"] == "Blocked One"           # bare-string title shape
+
+    def test_no_taskinfo_degrades_gracefully(self, tmp_path):
+        procs = odin_service.list_procedures(bundle=_make_bundle(tmp_path),
+                                             runnable_only=False)
+        noinfo = next(p for p in procs if p["name"] == "NOINFO-TASK")
+        assert noinfo["runnable"] is True
+        assert noinfo["title"] is None
+        assert noinfo["valid_states"] == [] and noinfo["principals"] == []
+
+    def test_runnable_only_filters_blocked(self, tmp_path):
+        procs = odin_service.list_procedures(bundle=_make_bundle(tmp_path),
+                                             runnable_only=True)
+        names = {p["name"] for p in procs}
+        assert names == {"RUNNABLE-TASK", "NOINFO-TASK"}   # BLOCKED-TASK dropped
+
+
+# ---------------------------------------------------------------------------
+# procedure_requirements -- "what must be on the bus before this proc runs"
+# ---------------------------------------------------------------------------
+# A lib graph exercising every extracted node kind: three CAN reads (read/monitor/
+# compare) on ETH, one DYNAMIC (connection-sourced) signal, an alert inspection, an
+# EnsureApplicationState (app-state precondition + a UDS target), a PowerContext, an
+# odx UDS target, and a cid data-value read. None need to be *handled* -- the walk
+# only visits node dicts.
+_REQ_LIB = '''
+network = {
+    "read": {"type": "can.CANSignalRead",
+             "signal_name": {"value": "GTW_drivetrainType"}, "bus_name": {"value": "ETH"}},
+    "mon": {"type": "can.CANSignalMonitor",
+            "signal_name": {"value": "DI_gear"}, "bus_name": {"value": "ETH"}},
+    "cmp": {"type": "can.CANSignalValueComparison",
+            "signal_name": {"value": "DIR_axleSpeed"}, "bus_name": {"value": "ETH"},
+            "target": {"value": 560}, "comparator": {"value": 4}},
+    "dyn": {"type": "can.CANSignalRead",
+            "signal_name": {"connection": "src.out"}, "bus_name": {"value": "ETH"}},
+    "def": {"type": "can.CANSignalRead",
+            "signal_name": {"connection": "src.out", "value": "IBST_iBoosterStatus"},
+            "bus_name": {"value": "ETH"}},
+    "alert": {"type": "can.ActiveAlerts",
+              "bus_name": {"value": "ETH"}, "prefix": {"value": "DI_a0"}},
+    "boot": {"type": "vehiclecontrols.EnsureApplicationState",
+             "node_name": {"value": "PMR"}, "application_state": {"value": "BOOTLOADER"}},
+    "pwr": {"type": "vehiclecontrols.PowerContext", "power_state": {"value": "DRIVE"}},
+    "uds": {"type": "odx.OdxStartRoutine", "node_name": {"value": "PMR"},
+            "routine_name": {"value": "Foo"}},
+    "cidv": {"type": "cid.GetDataValue", "data_name": {"value": "carVin"}},
+}
+'''
+# Entry proc that references the lib (so the walk is transitive) + TaskInfo states.
+_REQ_TASK = '''
+network = {
+    "task": {"type": "networks.RunReferencedSubnetwork", "basename": "Model3/lib/reqlib"},
+    "info": {"type": "comments.TaskInfo", "title": {"value": "Req Test"},
+             "valid_states": ["Parked"]},
+}
+'''
+# A read whose signal is literal but bus is absent -> grouped under the default bus.
+_REQ_DEFBUS = '''
+network = {
+    "r": {"type": "can.CANSignalRead", "signal_name": {"value": "BMS_state"}},
+}
+'''
+
+
+class TestProcedureRequirements:
+    def _bundle(self, tmp_path):
+        _write(tmp_path, "Model3/lib/reqlib", _REQ_LIB)
+        _write(tmp_path, "Model3/tasks/REQ", _REQ_TASK)
+        return tmp_path
+
+    def test_groups_signals_by_bus_with_kind(self, tmp_path):
+        req = odin_service.procedure_requirements(
+            "Model3/tasks/REQ", bundle=self._bundle(tmp_path))
+        assert req["basename"] == "Model3/tasks/REQ"
+        # literal reads on ETH, sorted by (signal, kind); the pure-connection dyn read
+        # is excluded, but the connection-with-default read IS enumerated at its default.
+        assert req["signals"]["ETH"] == [
+            {"signal": "DIR_axleSpeed", "kind": "compare"},
+            {"signal": "DI_gear", "kind": "monitor"},
+            {"signal": "GTW_drivetrainType", "kind": "read"},
+            {"signal": "IBST_iBoosterStatus", "kind": "read"},   # from a conn+value default
+        ]
+
+    def test_dynamic_signal_counted_not_enumerated(self, tmp_path):
+        req = odin_service.procedure_requirements(
+            "Model3/tasks/REQ", bundle=self._bundle(tmp_path))
+        assert req["dynamic_count"] == 1        # only the pure-connection read (no default)
+        sigs = [s["signal"] for lst in req["signals"].values() for s in lst]
+        assert "src.out" not in sigs            # the bare connection is never enumerated
+
+    def test_alerts_and_uds_target_nodes(self, tmp_path):
+        req = odin_service.procedure_requirements(
+            "Model3/tasks/REQ", bundle=self._bundle(tmp_path))
+        assert req["alerts"] == [{"bus": "ETH", "prefix": "DI_a0"}]
+        assert req["nodes"] == ["PMR"]      # odx + EnsureApplicationState, de-duped
+
+    def test_preconditions(self, tmp_path):
+        pre = odin_service.procedure_requirements(
+            "Model3/tasks/REQ", bundle=self._bundle(tmp_path))["preconditions"]
+        assert pre["valid_states"] == ["Parked"]
+        assert pre["application_state"] == "BOOTLOADER"
+        assert pre["power_state"] == "DRIVE"
+        assert pre["cid_values"] == ["carVin"]
+
+    def test_absent_bus_falls_back_to_vehicle(self, tmp_path):
+        _write(tmp_path, "Model3/tasks/DEFBUS", _REQ_DEFBUS)
+        req = odin_service.procedure_requirements("Model3/tasks/DEFBUS", bundle=tmp_path)
+        import config
+        assert req["signals"][config.canonical_bus(None)] == [
+            {"signal": "BMS_state", "kind": "read"}]
+
+    def test_unknown_procedure_raises(self, tmp_path):
+        import pytest
+        with pytest.raises(FileNotFoundError):
+            odin_service.procedure_requirements("Model3/tasks/NOPE", bundle=tmp_path)
+
+
+# A tiny entry proc that captures one metric then exits 0.
+_CAP_TASK = '''
+network = {
+    "enter": {"type": "networks.Enter", "start": {"connection": "cap.capture"}},
+    "cap": {"type": "reporting.CaptureMetric", "metric_name": {"value": "m"},
+            "value": {"value": 42}, "result_code": {"value": 0},
+            "done": {"connection": "exit.exit"}},
+    "exit": {"type": "networks.Exit", "exit_code": {"value": 0}},
+}
+'''
+
+
+class TestRunProcedure:
+    def test_returns_result_dict(self, tmp_path):
+        _write(tmp_path, "Model3/tasks/CAP", _CAP_TASK)
+        res = odin_service.run_procedure("Model3/tasks/CAP", backend="mock",
+                                         bundle=tmp_path)
+        assert res["exit_code"] == 0
+        assert res["passed"] is True
+        assert res["basename"] == "Model3/tasks/CAP"
+        assert [m["value"] for m in res["metrics"]] == [42]
+
+    def test_on_event_streams_trace_metric_and_done(self, tmp_path):
+        _write(tmp_path, "Model3/tasks/CAP", _CAP_TASK)
+        events: list[tuple] = []
+        res = odin_service.run_procedure(
+            "Model3/tasks/CAP", backend="mock", bundle=tmp_path,
+            on_event=lambda kind, payload: events.append((kind, payload)))
+
+        kinds = [k for k, _ in events]
+        assert "trace" in kinds                            # node execution steps
+        metrics = [p for k, p in events if k == "metric"]
+        assert metrics and metrics[0]["metric"] == "m" and metrics[0]["value"] == 42
+        # the terminal event carries the same dict run_procedure returns
+        assert kinds[-1] == "done"
+        assert events[-1][1] == res
+
+    def test_passed_backend_instance_is_not_closed(self, tmp_path):
+        _write(tmp_path, "Model3/tasks/CAP", _CAP_TASK)
+
+        class _TrackingBackend(odin_runner.MockBackend):
+            closed = False
+
+            def close(self):
+                self.closed = True
+
+        be = _TrackingBackend("success")
+        res = odin_service.run_procedure("Model3/tasks/CAP", backend=be,
+                                         bundle=tmp_path)
+        assert res["passed"] is True
+        assert be.closed is False        # caller owns a passed-in backend instance
+
+    def test_error_event_emitted_on_failure(self, tmp_path):
+        # A missing basename makes Engine.run_procedure raise (file not found);
+        # run_procedure must emit an 'error' event before propagating.
+        events: list[tuple] = []
+        raised = False
+        try:
+            odin_service.run_procedure(
+                "Model3/tasks/DOES-NOT-EXIST", backend="mock", bundle=tmp_path,
+                on_event=lambda kind, payload: events.append((kind, payload)))
+        except Exception:  # noqa: BLE001
+            raised = True
+        assert raised
+        assert events and events[-1][0] == "error"
+
+
+# ---------------------------------------------------------------------------
+# DID read/write helpers -- FakeSession + synthetic NodeConfig (no bench).
+# ---------------------------------------------------------------------------
+def _fs(bit_length, byte_position, bit_position=0, data_type="uint", enum=None):
+    return FieldSpec(bit_length=bit_length, byte_position=byte_position,
+                     bit_position=bit_position, data_type=data_type,
+                     enum_map=enum or {})
+
+
+_MODE = _fs(8, 0, 0, "uint", {"OFF": 0, "ON": 1})
+# CFG: readable (sl0, MODE enum) + writable (sl5, MODE enum).
+_CFG = OdjEntry(
+    name="CFG", hex_id=0x0500,
+    read=SubSpec(security_level=0, input={}, output={"MODE": _MODE},
+                 input_size=0, output_size=1),
+    write=SubSpec(security_level=5, input={"MODE": _MODE}, output={},
+                  input_size=1, output_size=0))
+# LOCK: read requires security level 3 (STATE byte).
+_LOCK = OdjEntry(
+    name="LOCK", hex_id=0x0600,
+    read=SubSpec(security_level=3, input={}, output={"STATE": _fs(8, 0)},
+                 input_size=0, output_size=1),
+    write=None)
+# SN: read-only ascii serial (sl0).
+_SN = OdjEntry(
+    name="SN", hex_id=0xF013,
+    read=SubSpec(security_level=0, input={}, output_size=4, input_size=0,
+                 output={"SN": _fs(32, 0, data_type="ascii")}),
+    write=None)
+
+
+def _did_cfg():
+    return NodeConfig(name="DI", request_can_id=0x1, response_can_id=0x2,
+                      security_algorithm="tesla_hash", security_buffer_size=16,
+                      security_kw={}, dids={"CFG": _CFG, "LOCK": _LOCK, "SN": _SN})
+
+
+class FakeSession:
+    """Records UDS calls; returns canned bytes for the synthetic DIDs above."""
+
+    def __init__(self, reads=None):
+        self.calls = []
+        self.reads = reads or {0x0500: b"\x01", 0x0600: b"\x07",
+                               0xF013: b"ABCD"}
+
+    def diagnostic_session(self, mode):
+        self.calls.append(("diagnostic_session", mode))
+
+    def security_access(self, level_idx=0, seed_level=None):
+        self.calls.append(("security_access", level_idx, seed_level))
+
+    def read_did(self, did):
+        self.calls.append(("read_did", did))
+        return self.reads.get(did, b"")
+
+    def write_did(self, did, data):
+        self.calls.append(("write_did", did, bytes(data)))
+
+
+class TestListDids:
+    def test_splits_readable_and_writable_with_metadata(self):
+        dids = odin_service.list_dids(_did_cfg())
+        assert {d["name"] for d in dids["read"]} == {"CFG", "LOCK", "SN"}
+        assert {d["name"] for d in dids["write"]} == {"CFG"}    # only CFG is writable
+        cfg_w = dids["write"][0]
+        assert cfg_w["hex_id"] == "0x0500" and cfg_w["security_level"] == 5
+        assert cfg_w["fields"] == ["MODE"]
+        lock = next(d for d in dids["read"] if d["name"] == "LOCK")
+        assert lock["security_level"] == 3
+
+
+class TestReadDid:
+    def test_decodes_enum_field(self):
+        sess = FakeSession()
+        res = odin_service.read_did(sess, _did_cfg(), "CFG")
+        assert res["hex_id"] == "0x0500"
+        assert res["fields"] == {"MODE": "ON"}    # 0x01 -> enum name
+        assert res["raw"] == "01"
+        assert ("read_did", 0x0500) in sess.calls
+
+    def test_parsed_false_keeps_raw_number(self):
+        res = odin_service.read_did(FakeSession(), _did_cfg(), "CFG", parsed=False)
+        assert res["fields"] == {"MODE": 1}
+
+    def test_read_runs_security_when_subspec_requires_it(self):
+        sess = FakeSession()
+        odin_service.read_did(sess, _did_cfg(), "LOCK")
+        assert ("diagnostic_session", 0x02) in sess.calls
+        assert ("security_access", 0, 3) in sess.calls    # seed_level = 3
+        assert ("read_did", 0x0600) in sess.calls
+
+    def test_resolves_by_hex_id(self):
+        res = odin_service.read_did(FakeSession(), _did_cfg(), "0x0500")
+        assert res["name"] == "CFG" and res["fields"] == {"MODE": "ON"}
+
+    def test_raw_id_not_in_odj_returns_bytes_no_fields(self):
+        sess = FakeSession(reads={0x1234: b"\xaa\xbb"})
+        res = odin_service.read_did(sess, _did_cfg(), 0x1234)
+        assert res["fields"] == {} and res["raw"] == "aabb"
+        assert res["name"] == "0x1234"
+
+
+class TestWriteDid:
+    def test_encode_did_write_from_named_values(self):
+        cfg = _did_cfg()
+        assert odin_service.encode_did_write(cfg, "CFG", {"MODE": "ON"})[2] == b"\x01"
+        assert odin_service.encode_did_write(cfg, "CFG", {"MODE": 1})[2] == b"\x01"
+
+    def test_encode_did_write_raw_passthrough(self):
+        cfg = _did_cfg()
+        assert odin_service.encode_did_write(cfg, "CFG", "0a 0b")[2] == b"\x0a\x0b"
+        assert odin_service.encode_did_write(cfg, "CFG", b"\xde\xad")[2] == b"\xde\xad"
+
+    def test_write_encodes_runs_security_then_writes(self):
+        sess = FakeSession()
+        res = odin_service.write_did(sess, _did_cfg(), "CFG", {"MODE": "ON"})
+        assert ("diagnostic_session", 0x02) in sess.calls
+        assert ("security_access", 0, 5) in sess.calls     # write subspec sl = 5
+        assert ("write_did", 0x0500, b"\x01") in sess.calls
+        assert res["bytes"] == "01" and res["size"] == 1
+
+    def test_security_can_be_skipped(self):
+        sess = FakeSession()
+        odin_service.write_did(sess, _did_cfg(), "CFG", {"MODE": "OFF"},
+                               security=False)
+        assert not any(c[0] == "security_access" for c in sess.calls)
+        assert ("write_did", 0x0500, b"\x00") in sess.calls

--- a/tests/test_odin_web.py
+++ b/tests/test_odin_web.py
@@ -1,0 +1,444 @@
+"""Tests for scripts/odin_web.py -- the aiohttp ODIN + DID endpoints.
+
+Self-contained: a synthetic bundle (Model3/tasks), a MockBackend for runs, and a
+fake node_provider (synthetic NodeConfig + FakeSession) for DID ops, so every
+endpoint is exercised against the aiohttp test client with no CAN bus. No
+pytest-asyncio: each test runs its async body under asyncio.run.
+"""
+import asyncio
+import contextlib
+import json
+from pathlib import Path
+
+import odin_web
+from aiohttp import WSMsgType, web
+from aiohttp.test_utils import TestClient, TestServer
+from odin_runner import MockBackend
+
+from uds_local.node_config import NodeConfig
+from uds_local.odj import FieldSpec, OdjEntry, SubSpec
+
+
+# --------------------------------------------------------------------------- bundle
+def _write(bundle: Path, relbase: str, src: str) -> None:
+    path = bundle / (relbase + ".py")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(src, encoding="utf-8")
+
+
+_CAP = '''
+network = {
+    "enter": {"type": "networks.Enter", "start": {"connection": "cap.capture"}},
+    "cap": {"type": "reporting.CaptureMetric", "metric_name": {"value": "m"},
+            "value": {"value": 42}, "result_code": {"value": 0},
+            "done": {"connection": "exit.exit"}},
+    "exit": {"type": "networks.Exit", "exit_code": {"value": 0}},
+    "info": {"type": "comments.TaskInfo", "title": "Cap It"},
+}
+'''
+_BLOCKED = '''
+network = {
+    "enter": {"type": "networks.Enter", "start": {"connection": "x.run"}},
+    "x": {"type": "custommod.CustomNode", "done": {"connection": "exit.exit"}},
+    "exit": {"type": "networks.Exit", "exit_code": {"value": 0}},
+    "info": {"type": "comments.TaskInfo", "title": "Blocked"},
+}
+'''
+# A proc reading one literal CAN signal on ETH (for the requirements endpoint).
+_REQ = '''
+network = {
+    "r": {"type": "can.CANSignalRead",
+          "signal_name": {"value": "GTW_drivetrainType"}, "bus_name": {"value": "ETH"}},
+    "info": {"type": "comments.TaskInfo", "title": "Req", "valid_states": ["Parked"]},
+}
+'''
+
+
+def _bundle(tmp_path: Path) -> Path:
+    _write(tmp_path, "Model3/tasks/CAP", _CAP)
+    _write(tmp_path, "Model3/tasks/BLOCKED", _BLOCKED)
+    return tmp_path
+
+
+# --------------------------------------------------------------------------- DID stubs
+def _fs(bit_length, byte_position, bit_position=0, data_type="uint", enum=None):
+    return FieldSpec(bit_length=bit_length, byte_position=byte_position,
+                     bit_position=bit_position, data_type=data_type, enum_map=enum or {})
+
+
+_MODE = _fs(8, 0, 0, "uint", {"OFF": 0, "ON": 1})
+_CFG = OdjEntry(
+    name="CFG", hex_id=0x0500,
+    read=SubSpec(security_level=0, input={}, output={"MODE": _MODE},
+                 input_size=0, output_size=1),
+    write=SubSpec(security_level=5, input={"MODE": _MODE}, output={},
+                  input_size=1, output_size=0))
+
+
+def _did_cfg():
+    return NodeConfig(name="DI", request_can_id=1, response_can_id=2,
+                      security_algorithm="tesla_hash", security_buffer_size=16,
+                      security_kw={}, dids={"CFG": _CFG})
+
+
+class FakeSession:
+    def __init__(self):
+        self.calls = []
+
+    def diagnostic_session(self, mode):
+        self.calls.append(("diagnostic_session", mode))
+
+    def security_access(self, level_idx=0, seed_level=None):
+        self.calls.append(("security_access", seed_level))
+
+    def read_did(self, did):
+        self.calls.append(("read_did", did))
+        return b"\x01"
+
+    def write_did(self, did, data):
+        self.calls.append(("write_did", did, bytes(data)))
+
+    # -- driven by the low-level UDS ops --
+    def ecu_reset(self, reset_type):
+        self.calls.append(("ecu_reset", reset_type))
+
+    def ecu_reset_no_wait(self, reset_type):
+        self.calls.append(("ecu_reset_no_wait", reset_type))
+
+    def start_tester_present(self):
+        self.calls.append(("tp_start",))
+
+    def stop_tester_present(self):
+        self.calls.append(("tp_stop",))
+
+    def routine_control(self, routine_id, arg=b"", subtype=0x01):
+        self.calls.append(("routine_control", routine_id, bytes(arg), subtype))
+        return b"\x01\x02"
+
+    def read_dtcs(self, status_mask=0xFF):
+        self.calls.append(("read_dtcs", status_mask))
+        return {0xC00100: 0x2F}
+
+    def clear_dtc(self, group=0xFFFFFF):
+        self.calls.append(("clear_dtc", group))
+
+
+class BootSession(FakeSession):
+    """read_did answers like a node sitting in its bootloader: 0xF180 byte 8 == 0
+    (fw_type BOOTLOADER) and 0xF181 (app-only) raising an NRC."""
+
+    def read_did(self, did):
+        self.calls.append(("read_did", did))
+        if did == 0xF180:
+            return bytes.fromhex("001122334455667700")
+        if did == 0xF181:
+            raise RuntimeError("NRC 0x31")
+        return b"\xde\xad"
+
+
+class FakeBackend:
+    """Just the seam the bootloader ops need off the real BenchBackend."""
+
+    def __init__(self):
+        self.states = []
+
+    def ensure_application_state(self, node, state):
+        self.states.append((node, state))
+
+
+def _mock_factory():
+    return MockBackend("success")
+
+
+@contextlib.asynccontextmanager
+async def _client(**kw):
+    app = web.Application()
+    odin_web.setup_routes(app, **kw)
+    async with TestClient(TestServer(app)) as client:
+        yield client
+
+
+# --------------------------------------------------------------------------- tests
+class TestProcedures:
+    def test_runnable_list(self, tmp_path):
+        async def body():
+            async with _client(bundle=_bundle(tmp_path)) as client:
+                r = await client.get("/api/odin/procedures")
+                assert r.status == 200
+                names = {p["name"] for p in await r.json()}
+                assert names == {"CAP"}          # runnable only; BLOCKED excluded
+        asyncio.run(body())
+
+    def test_all_includes_blocked(self, tmp_path):
+        async def body():
+            async with _client(bundle=_bundle(tmp_path)) as client:
+                r = await client.get("/api/odin/procedures?all=1")
+                procs = {p["name"]: p for p in await r.json()}
+                assert set(procs) == {"CAP", "BLOCKED"}
+                assert procs["BLOCKED"]["runnable"] is False
+                assert "custommod.CustomNode" in procs["BLOCKED"]["missing_types"]
+        asyncio.run(body())
+
+
+class TestRequirements:
+    def test_returns_signals_grouped_by_bus(self, tmp_path):
+        async def body():
+            _write(_bundle(tmp_path), "Model3/tasks/REQ", _REQ)
+            async with _client(bundle=tmp_path) as client:
+                r = await client.get("/api/odin/requirements?procedure=Model3/tasks/REQ")
+                assert r.status == 200
+                req = await r.json()
+                assert req["signals"]["ETH"] == [
+                    {"signal": "GTW_drivetrainType", "kind": "read"}]
+                assert req["preconditions"]["valid_states"] == ["Parked"]
+                assert req["dynamic_count"] == 0
+        asyncio.run(body())
+
+    def test_missing_procedure_param_is_400(self, tmp_path):
+        async def body():
+            async with _client(bundle=_bundle(tmp_path)) as client:
+                r = await client.get("/api/odin/requirements")
+                assert r.status == 400
+        asyncio.run(body())
+
+    def test_unknown_procedure_is_404(self, tmp_path):
+        async def body():
+            async with _client(bundle=_bundle(tmp_path)) as client:
+                r = await client.get("/api/odin/requirements?procedure=Model3/tasks/NOPE")
+                assert r.status == 404
+        asyncio.run(body())
+
+
+class TestRun:
+    def test_run_returns_result(self, tmp_path):
+        async def body():
+            async with _client(bundle=_bundle(tmp_path),
+                               backend_factory=_mock_factory) as client:
+                r = await client.post("/api/odin/run",
+                                      json={"procedure": "Model3/tasks/CAP"})
+                assert r.status == 200
+                res = await r.json()
+                assert res["passed"] is True and res["exit_code"] == 0
+                assert [m["value"] for m in res["metrics"]] == [42]
+        asyncio.run(body())
+
+    def test_missing_procedure_is_400(self, tmp_path):
+        async def body():
+            async with _client(bundle=_bundle(tmp_path)) as client:
+                r = await client.post("/api/odin/run", json={})
+                assert r.status == 400
+        asyncio.run(body())
+
+    def test_second_run_while_locked_is_409(self, tmp_path):
+        async def body():
+            async with _client(bundle=_bundle(tmp_path),
+                               backend_factory=_mock_factory) as client:
+                svc = client.app[odin_web.ODIN_WEB]
+                await svc._run_lock.acquire()      # simulate an in-flight run
+                try:
+                    r = await client.post("/api/odin/run",
+                                          json={"procedure": "Model3/tasks/CAP"})
+                    assert r.status == 409
+                finally:
+                    svc._run_lock.release()
+        asyncio.run(body())
+
+    def test_ws_streams_metric_and_done(self, tmp_path):
+        async def body():
+            async with _client(bundle=_bundle(tmp_path),
+                               backend_factory=_mock_factory) as client:
+                ws = await client.ws_connect("/ws/odin")
+                r = await client.post("/api/odin/run",
+                                      json={"procedure": "Model3/tasks/CAP"})
+                assert r.status == 200
+                events = []
+                while True:
+                    msg = await asyncio.wait_for(ws.receive(), timeout=5)
+                    if msg.type == WSMsgType.TEXT:
+                        d = json.loads(msg.data)
+                        events.append(d)
+                        if d["type"] == "done":
+                            break
+                    elif msg.type in (WSMsgType.CLOSED, WSMsgType.ERROR):
+                        break
+                await ws.close()
+                kinds = [e["type"] for e in events]
+                assert "metric" in kinds and kinds[-1] == "done"
+                metric = next(e for e in events if e["type"] == "metric")
+                assert metric["metric"] == "m" and metric["value"] == 42
+        asyncio.run(body())
+
+
+class TestDid:
+    def test_list(self):
+        async def body():
+            sess = FakeSession()
+            async with _client(node_provider=lambda n: (_did_cfg(), sess)) as client:
+                r = await client.get("/api/did/DI")
+                assert r.status == 200
+                dids = await r.json()
+                assert [d["name"] for d in dids["read"]] == ["CFG"]
+                assert dids["write"][0]["security_level"] == 5
+        asyncio.run(body())
+
+    def test_read_decodes_enum(self):
+        async def body():
+            sess = FakeSession()
+            async with _client(node_provider=lambda n: (_did_cfg(), sess)) as client:
+                r = await client.post("/api/did/read",
+                                      json={"node": "DI", "did": "CFG"})
+                assert r.status == 200
+                res = await r.json()
+                assert res["fields"] == {"MODE": "ON"} and res["raw"] == "01"
+        asyncio.run(body())
+
+    def test_write_encodes_and_runs_security(self):
+        async def body():
+            sess = FakeSession()
+            async with _client(node_provider=lambda n: (_did_cfg(), sess)) as client:
+                r = await client.post("/api/did/write",
+                                      json={"node": "DI", "did": "CFG",
+                                            "values": {"MODE": "ON"}})
+                assert r.status == 200
+                assert ("security_access", 5) in sess.calls
+                assert ("write_did", 0x0500, b"\x01") in sess.calls
+        asyncio.run(body())
+
+    def test_did_without_provider_is_503(self):
+        async def body():
+            async with _client() as client:      # no node_provider
+                r = await client.get("/api/did/DI")
+                assert r.status == 503
+        asyncio.run(body())
+
+
+class TestLowLevelUds:
+    """The generic UDS primitives exposed alongside the packaged procedures."""
+
+    def test_catalog_lists_ops_with_danger_flags(self):
+        async def body():
+            async with _client() as client:
+                r = await client.get("/api/uds/ops")
+                assert r.status == 200
+                ops = await r.json()
+                by_id = {o["op"]: o for o in ops}
+                assert "enter_bootloader" in by_id and "probe_state" in by_id
+                # Anything that reboots the ECU must be flagged so the UI confirms.
+                assert by_id["enter_bootloader"]["danger"] is True
+                assert by_id["ecu_reset"]["danger"] is True
+                assert "danger" not in by_id["probe_state"]
+        asyncio.run(body())
+
+    def test_probe_state_reads_fw_type_and_f181(self):
+        async def body():
+            sess = BootSession()
+            async with _client(node_provider=lambda n: (_did_cfg(), sess)) as client:
+                r = await client.post("/api/uds/op",
+                                      json={"node": "DI", "op": "probe_state"})
+                assert r.status == 200
+                res = (await r.json())["result"]
+                assert res["fw_type"] == 0
+                assert res["state"] == "BOOTLOADER"
+                assert res["f181"] == "NRC (bootloader)"
+        asyncio.run(body())
+
+    def test_enter_bootloader_uses_backend_handover(self):
+        async def body():
+            sess, backend = BootSession(), FakeBackend()
+            async with _client(backend_factory=lambda: backend,
+                               node_provider=lambda n: (_did_cfg(), sess)) as client:
+                r = await client.post("/api/uds/op",
+                                      json={"node": "DI", "op": "enter_bootloader"})
+                assert r.status == 200
+                assert backend.states == [("DI", "BOOTLOADER")]
+                # and it reports back what the node now says it is
+                assert (await r.json())["result"]["probe"]["state"] == "BOOTLOADER"
+        asyncio.run(body())
+
+    def test_enter_bootloader_without_any_backend_is_400(self):
+        async def body():
+            sess = BootSession()
+            # No backend_factory at all -> nothing to drive the handover with.
+            # (MockBackend does implement the seam, so it is NOT the no-bench case.)
+            async with _client(node_provider=lambda n: (_did_cfg(), sess)) as client:
+                r = await client.post("/api/uds/op",
+                                      json={"node": "DI", "op": "enter_bootloader"})
+                assert r.status == 400
+                assert "bench backend" in (await r.json())["error"]
+        asyncio.run(body())
+
+    def test_ecu_reset_honours_type_and_no_wait(self):
+        async def body():
+            sess = FakeSession()
+            async with _client(node_provider=lambda n: (_did_cfg(), sess)) as client:
+                r = await client.post("/api/uds/op", json={
+                    "node": "DI", "op": "ecu_reset",
+                    "args": {"type": "soft", "no_wait": True}})
+                assert r.status == 200
+                assert ("ecu_reset_no_wait", 0x03) in sess.calls
+
+                await client.post("/api/uds/op", json={
+                    "node": "DI", "op": "ecu_reset", "args": {"type": "hard"}})
+                assert ("ecu_reset", 0x01) in sess.calls
+        asyncio.run(body())
+
+    def test_hex_fields_parse_as_hex_not_decimal(self):
+        async def body():
+            sess = FakeSession()
+            async with _client(node_provider=lambda n: (_did_cfg(), sess)) as client:
+                r = await client.post("/api/uds/op", json={
+                    "node": "DI", "op": "routine_control",
+                    "args": {"routine_id": "0403", "subtype": 1, "arg": "01 ff"}})
+                assert r.status == 200
+                # 0403 is hex 0x0403 (1027), NOT decimal 403
+                assert ("routine_control", 0x0403, b"\x01\xff", 1) in sess.calls
+                assert (await r.json())["result"]["routine"] == "0x0403"
+        asyncio.run(body())
+
+    def test_read_dtcs_and_clear(self):
+        async def body():
+            sess = FakeSession()
+            async with _client(node_provider=lambda n: (_did_cfg(), sess)) as client:
+                r = await client.post("/api/uds/op",
+                                      json={"node": "DI", "op": "read_dtcs"})
+                res = (await r.json())["result"]
+                assert res["count"] == 1
+                assert res["dtcs"] == [{"dtc": "0xC00100", "status": "0x2F"}]
+
+                r = await client.post("/api/uds/op", json={
+                    "node": "DI", "op": "clear_dtc", "args": {"group": "FFFFFF"}})
+                assert r.status == 200
+                assert ("clear_dtc", 0xFFFFFF) in sess.calls
+        asyncio.run(body())
+
+    def test_unknown_op_and_missing_node_are_400(self):
+        async def body():
+            sess = FakeSession()
+            async with _client(node_provider=lambda n: (_did_cfg(), sess)) as client:
+                r = await client.post("/api/uds/op",
+                                      json={"node": "DI", "op": "not-an-op"})
+                assert r.status == 400
+                r = await client.post("/api/uds/op", json={"op": "probe_state"})
+                assert r.status == 400
+        asyncio.run(body())
+
+    def test_uds_op_without_provider_is_503(self):
+        async def body():
+            async with _client() as client:      # no node_provider
+                r = await client.post("/api/uds/op",
+                                      json={"node": "DI", "op": "probe_state"})
+                assert r.status == 503
+        asyncio.run(body())
+
+    def test_nrc_from_the_ecu_becomes_400_not_500(self):
+        async def body():
+            class Boom(FakeSession):
+                def read_did(self, did):
+                    raise RuntimeError("NRC 0x33 securityAccessDenied")
+
+            async with _client(node_provider=lambda n: (_did_cfg(), Boom())) as client:
+                r = await client.post("/api/uds/op", json={
+                    "node": "DI", "op": "read_did_raw", "args": {"did": "F190"}})
+                assert r.status == 400
+                assert "securityAccessDenied" in (await r.json())["error"]
+        asyncio.run(body())

--- a/tests/test_odj_codec.py
+++ b/tests/test_odj_codec.py
@@ -1,0 +1,182 @@
+"""Tests for uds_local/odj_codec.py.
+
+Self-contained: the FieldSpec/SubSpec layouts here mirror the REAL DIR ODJ
+RESOLVER_LEARNING / OFFSET_LEARNING results specs (dumped from firmware), so the
+codec is validated against ground truth without needing the ODJ files present.
+Expected values are cross-checked against scripts/di/resolver_cal.py's hand-parse.
+"""
+import struct
+
+from uds_local.odj import FieldSpec, SubSpec
+from uds_local.odj_codec import (
+    decode_field,
+    decode_response,
+    encode_fields,
+    encode_request,
+)
+
+_RUNNING_ENUM = {"FALSE": 0, "TRUE": 1}
+_RESOLVER_ENUM = {"LEARN_SUCCESS": 0, "TEST_FAILED": 1, "OFF_LIMITS": 2,
+                  "START_SPEED": 3, "SPEED_RANGE": 4, "TORQUE": 5, "BRAKE": 6,
+                  "FAULT": 7}
+_OFFSET_ENUM = {"SUCCESS": 0, "FAIL_BRAKES": 1, "FAIL_INVALID_GEAR": 2,
+                "FAIL_NEG_SPEED": 3, "FAIL_OVER_SPEED": 4, "FAIL_TIMEOUT": 7}
+
+
+def _fs(bit_length, byte_position, bit_position=0, data_type="uint", enum=None):
+    return FieldSpec(bit_length=bit_length, byte_position=byte_position,
+                     bit_position=bit_position, data_type=data_type,
+                     enum_map=enum or {})
+
+
+# Mirrors DIR RESOLVER_LEARNING.results (out_size 187).
+_RESOLVER_RESULTS = SubSpec(
+    security_level=0, input={}, input_size=0, output_size=187,
+    output={
+        "ERRORTABLE": _fs(1472, 0, data_type="bytes"),
+        "RMSERROR": _fs(16, 184, data_type="int"),
+        "LEARN_RESULT": _fs(3, 186, 0, "uint", _RESOLVER_ENUM),
+        "WRITE_FAILED": _fs(1, 186, 3, "uint", _RUNNING_ENUM),
+        "RUNNING": _fs(1, 186, 4, "uint", _RUNNING_ENUM),
+    })
+
+# Mirrors DIR OFFSET_LEARNING.results (out_size 17).
+_OFFSET_RESULTS = SubSpec(
+    security_level=5, input={}, input_size=0, output_size=17,
+    output={
+        "INITIAL_OFFSET": _fs(32, 0, data_type="int"),
+        "FINAL_OFFSET": _fs(32, 4, data_type="int"),
+        "FINAL_VD": _fs(32, 8, data_type="int"),
+        "FINAL_VQ": _fs(32, 12, data_type="int"),
+        "LEARN_RESULT": _fs(4, 16, 0, "uint", _OFFSET_ENUM),
+    })
+
+
+def _resolver_payload(table: bytes, rms: int, flags: int) -> bytes:
+    assert len(table) == 184
+    return table + struct.pack(">h", rms) + bytes([flags])
+
+
+class TestResolverDecode:
+    def test_running_speed_range(self):
+        table = bytes(i % 256 for i in range(184))
+        # flags 0x14: LEARN_RESULT=4 (bits0-2), WRITE_FAILED=0 (bit3), RUNNING=1 (bit4)
+        out = decode_response(_RESOLVER_RESULTS, _resolver_payload(table, 256, 0x14))
+        assert out["ERRORTABLE"] == table          # type=bytes -> raw 184 bytes
+        assert out["RMSERROR"] == 256              # int16 BE (raw; scaling is caller-side)
+        assert out["LEARN_RESULT"] == "SPEED_RANGE"
+        assert out["RUNNING"] is True              # TRUE/FALSE enum -> bool
+        assert out["WRITE_FAILED"] is False
+
+    def test_success_idle(self):
+        out = decode_response(_RESOLVER_RESULTS, _resolver_payload(b"\x00" * 184, 0, 0x00))
+        assert out["LEARN_RESULT"] == "LEARN_SUCCESS"
+        assert out["RUNNING"] is False
+
+    def test_raw_mode_skips_enum(self):
+        raw = decode_response(_RESOLVER_RESULTS, _resolver_payload(b"\x00" * 184, 0, 0x14),
+                              parsed=False)
+        assert raw["LEARN_RESULT"] == 4
+        assert raw["RUNNING"] == 1
+
+    def test_matches_resolver_cal_bitmath(self):
+        # cross-check the exact expressions resolver_cal.parse_resolver_result uses
+        flags = 0x1C  # LEARN=4? no: 0x1C = 0b0001_1100 -> LEARN=4, WRITE=1(bit3), RUN=1(bit4)
+        out = decode_response(_RESOLVER_RESULTS, _resolver_payload(b"\x00" * 184, 0, flags),
+                              parsed=False)
+        assert out["LEARN_RESULT"] == (flags & 0x07)
+        assert out["WRITE_FAILED"] == ((flags >> 3) & 1)
+        assert out["RUNNING"] == ((flags >> 4) & 1)
+
+
+class TestOffsetDecode:
+    def test_signed_int32_fields(self):
+        data = struct.pack(">iiii", 1000, -2000, 5, -5) + bytes([0x00])
+        out = decode_response(_OFFSET_RESULTS, data)
+        assert out["INITIAL_OFFSET"] == 1000
+        assert out["FINAL_OFFSET"] == -2000
+        assert out["FINAL_VD"] == 5
+        assert out["FINAL_VQ"] == -5
+        assert out["LEARN_RESULT"] == "SUCCESS"
+
+    def test_fail_enum(self):
+        data = struct.pack(">iiii", 0, 0, 0, 0) + bytes([0x04])
+        assert decode_response(_OFFSET_RESULTS, data)["LEARN_RESULT"] == "FAIL_OVER_SPEED"
+
+
+class TestPrimitiveDecode:
+    def test_ascii(self):
+        fs = _fs(112, 0, data_type="ascii")
+        assert decode_field(fs, b"ABCDEFGHIJKLMN") == "ABCDEFGHIJKLMN"
+
+    def test_ascii_strips_nul(self):
+        fs = _fs(64, 0, data_type="ascii")
+        assert decode_field(fs, b"AB\x00\x00\x00\x00\x00\x00") == "AB"
+
+    def test_uint_be(self):
+        assert decode_field(_fs(32, 0, data_type="uint"), b"\x00\x00\x01\x00") == 256
+
+    def test_short_payload_returns_none(self):
+        assert decode_field(_fs(16, 10), b"\x00\x00") is None
+
+
+class TestEncode:
+    def test_byte_fields(self):
+        sub = SubSpec(security_level=0, input_size=2, output_size=0, output={},
+                      input={"CHANNEL": _fs(8, 0), "MODE": _fs(8, 1)})
+        assert encode_request(sub, {"CHANNEL": 3, "MODE": 7}) == b"\x03\x07"
+
+    def test_enum_name_input(self):
+        sub = SubSpec(security_level=0, input_size=1, output_size=0, output={},
+                      input={"STATE": _fs(8, 0, 0, "uint", {"ON": 1, "OFF": 0})})
+        assert encode_request(sub, {"STATE": "ON"}) == b"\x01"
+
+    def test_int16_be(self):
+        sub = SubSpec(security_level=0, input_size=2, output_size=0, output={},
+                      input={"V": _fs(16, 0, data_type="int")})
+        assert encode_request(sub, {"V": -1}) == b"\xff\xff"
+
+    def test_sub_byte_bitfield(self):
+        sub = SubSpec(security_level=0, input_size=1, output_size=0, output={},
+                      input={"FLAG": _fs(1, 0, 4, "uint")})
+        assert encode_request(sub, {"FLAG": 1}) == b"\x10"
+
+    def test_absent_field_is_zero_fill(self):
+        sub = SubSpec(security_level=0, input_size=2, output_size=0, output={},
+                      input={"A": _fs(8, 0), "B": _fs(8, 1)})
+        assert encode_request(sub, {"A": 0xAB}) == b"\xab\x00"
+
+    def test_no_input_spec(self):
+        assert encode_request(None, {}) == b""
+
+    def test_multibyte_field_is_big_endian(self):
+        # Regression: byte-aligned multi-byte inputs go out big-endian (the wire
+        # convention). tm3diag's old _prompt_routine_inputs hand-packed LSB-first,
+        # so 0x1234 wrongly became b"\x34\x12".
+        sub = SubSpec(security_level=0, input_size=2, output_size=0, output={},
+                      input={"V": _fs(16, 0, data_type="uint")})
+        assert encode_request(sub, {"V": 0x1234}) == b"\x12\x34"
+
+
+class TestEncodeFields:
+    """encode_fields: the shared packer under encode_request, also used directly for
+    IO controls (which carry a bare fields dict + input_size, not a SubSpec)."""
+
+    def test_big_endian_and_padding(self):
+        # 16-bit field at byte 1, input_size 4 -> byte 0 + trailing byte zero-filled.
+        fields = {"V": _fs(16, 1, data_type="uint")}
+        assert encode_fields(fields, {"V": 0x00FF}, 4) == b"\x00\x00\xff\x00"
+
+    def test_sub_byte_and_enum(self):
+        fields = {"FLAG": _fs(1, 0, 4, "uint"),
+                  "MODE": _fs(8, 1, 0, "uint", {"ON": 1, "OFF": 0})}
+        assert encode_fields(fields, {"FLAG": 1, "MODE": "ON"}, 2) == b"\x10\x01"
+
+    def test_empty_fields(self):
+        assert encode_fields({}, {"X": 1}, 4) == b""
+
+    def test_encode_request_delegates(self):
+        sub = SubSpec(security_level=0, input_size=2, output_size=0, output={},
+                      input={"A": _fs(8, 0), "B": _fs(8, 1)})
+        assert encode_request(sub, {"A": 1, "B": 2}) == encode_fields(
+            sub.input, {"A": 1, "B": 2}, sub.input_size) == b"\x01\x02"

--- a/uds_local/client.py
+++ b/uds_local/client.py
@@ -49,6 +49,7 @@ _SID_ER = 0x11  # ECUReset
 _SID_TP = 0x3E  # TesterPresent
 _SID_CDI = 0x14  # ClearDiagnosticInformation
 _SID_IOCBI = 0x2F  # InputOutputControlByIdentifier
+_SID_RDTC = 0x19  # ReadDTCInformation
 
 _RC_START = 0x01
 _RC_REQUEST_RESULTS = 0x03
@@ -712,6 +713,22 @@ class UdsSession:
         b = group.to_bytes(3, "big")
         resp = self._send_raw([_SID_CDI, b[0], b[1], b[2]])
         self._check_positive(resp, _SID_CDI)
+
+    def read_dtcs(self, status_mask: int = 0xFF) -> dict[int, int]:
+        """ReadDTCInformation reportDTCByStatusMask (0x19 02) — return {dtc_code:
+        status} for stored DTCs whose status matches ``status_mask`` (0xFF = any).
+
+        Positive response is ``59 02 <availabilityMask> [<dtc hi mid lo> <status>]*``;
+        the empty case (a healthy ECU) returns an empty dict.
+        """
+        resp = self._send_raw([_SID_RDTC, 0x02, status_mask & 0xFF])
+        self._check_positive(resp, _SID_RDTC)
+        out: dict[int, int] = {}
+        body = resp[3:]  # skip 59 02 <availabilityMask>
+        for i in range(0, len(body) - 3, 4):
+            dtc = (body[i] << 16) | (body[i + 1] << 8) | body[i + 2]
+            out[dtc] = body[i + 3]
+        return out
 
     # ------------------------------------------------------------------
     # Internal helpers

--- a/uds_local/datastore.py
+++ b/uds_local/datastore.py
@@ -1,0 +1,87 @@
+"""Persistent, board-keyed interop data store (odin_data.json).
+
+One gitignored JSON, ``{board_id: {namespace: {key: value}}}``. The board id is the
+board serial number (DID 0xF013) -- the same key the immobilizer already uses.
+Namespaces group data by producer:
+
+  * ``immo``    -- optional per-board key material written by a user-supplied
+                   immobilizer provider (see docs/SECURITY_PROVIDER.md); absent
+                   unless such a provider is configured
+  * ``outputs`` -- outputs captured from an ODIN procedure run (scripts/odin_runner)
+
+This is the single place bench interop persists per-board state, so anything that
+needs a board's key / prior outputs reads it from here.
+"""
+from __future__ import annotations
+
+import contextlib
+import json
+from pathlib import Path
+
+# Lives at the project root; gitignored (see .gitignore).
+DEFAULT_PATH = Path(__file__).resolve().parent.parent / "odin_data.json"
+
+
+def json_safe(obj):
+    """Recursively coerce a value to something json.dumps accepts: bytes -> hex
+    string, tuples -> lists, dict keys -> str. ODIN procedure outputs carry raw
+    bytes (odometer / resolver-calibration blobs), so sanitize before storing."""
+    if isinstance(obj, (bytes, bytearray)):
+        return obj.hex()
+    if isinstance(obj, dict):
+        return {str(k): json_safe(v) for k, v in obj.items()}
+    if isinstance(obj, (list, tuple)):
+        return [json_safe(v) for v in obj]
+    return obj
+
+
+class DataStore:
+    """``{board_id: {namespace: {key: value}}}`` persisted to one JSON file.
+
+    Board ids and namespaces are strings; values are JSON-serializable. Writes save
+    immediately (the file is small and written rarely). Missing lookups return empty
+    -- callers treat "no data for this board/namespace" as the common case.
+    """
+
+    def __init__(self, path: Path | str = DEFAULT_PATH) -> None:
+        self.path = Path(path)
+        self._data: dict[str, dict] = {}
+        if self.path.exists():
+            self.load()
+
+    def load(self) -> None:
+        with contextlib.suppress(json.JSONDecodeError, OSError):
+            loaded = json.loads(self.path.read_text())
+            if isinstance(loaded, dict):
+                self._data = loaded
+
+    def save(self) -> None:
+        self.path.write_text(json.dumps(self._data, indent=2, sort_keys=True) + "\n")
+
+    def _board(self, board_id) -> dict:
+        return self._data.setdefault(str(board_id), {})
+
+    def get(self, board_id, namespace: str) -> dict:
+        """A copy of one namespace's ``{key: value}`` for a board (``{}`` if absent)."""
+        return dict(self._data.get(str(board_id), {}).get(namespace, {}))
+
+    def has(self, board_id, namespace: str) -> bool:
+        return bool(self._data.get(str(board_id), {}).get(namespace))
+
+    def put(self, board_id, namespace: str, key: str, value) -> None:
+        """Set one key in a namespace and persist."""
+        self._board(board_id).setdefault(namespace, {})[key] = value
+        self.save()
+
+    def update(self, board_id, namespace: str, mapping: dict,
+               *, replace: bool = False) -> None:
+        """Merge (default) or replace a namespace's mapping and persist."""
+        board = self._board(board_id)
+        if replace or not isinstance(board.get(namespace), dict):
+            board[namespace] = dict(mapping)
+        else:
+            board[namespace].update(mapping)
+        self.save()
+
+    def boards(self) -> list[str]:
+        return list(self._data)

--- a/uds_local/odj_codec.py
+++ b/uds_local/odj_codec.py
@@ -1,0 +1,139 @@
+"""Encode UDS request payloads / decode response payloads from ODJ field specs.
+
+Generalizes the hand-written parse in ``scripts/di/resolver_cal.py`` into a
+table-driven codec off the ODJ ``SubSpec``/``FieldSpec`` metadata, so the ODIN
+runner's odx.* nodes (start/stop/results routines, read/write DID) can name
+parameters instead of slicing bytes.
+
+Wire convention (confirmed against the DIR ``RESOLVER_LEARNING``/``OFFSET_LEARNING``
+results specs, which match resolver_cal byte-for-byte):
+  * Byte-aligned multi-byte fields (``bit_position == 0`` and ``bit_length`` a
+    multiple of 8) are **big-endian** -- the C28x ECUs byte-swap each 16-bit word
+    before returning it, so on the wire the high byte comes first. ``int`` is
+    signed, ``uint`` unsigned, ``ascii``/``bytes`` returned as text/raw.
+  * Sub-byte fields are **LSB-relative bit fields** within the byte at
+    ``byte_position`` (e.g. ``RUNNING`` = bit 4 of byte 186).
+
+``parsed=True`` applies ``enum_map`` (raw value -> enum name); ``parsed=False``
+returns the raw number -- the OdxGetParsedValue vs OdxGetRawValue distinction.
+
+NOTE: ``odj.FieldSpec`` currently carries only the *enum* map, not *linear*
+(slope/offset) scaling, so a parsed scaled field (e.g. RMSERROR x 1/512) decodes
+as its raw integer. Enum-status fields -- what graphs branch on -- are exact;
+adding linear scaling is a follow-up in odj.py + here.
+"""
+from __future__ import annotations
+
+from .odj import FieldSpec, SubSpec
+
+
+class OdjCodecError(ValueError):
+    """A field layout the codec can't (yet) encode/decode."""
+
+
+def _byte_aligned(fs: FieldSpec) -> bool:
+    return fs.bit_position == 0 and fs.bit_length % 8 == 0
+
+
+def decode_field(fs: FieldSpec, data: bytes, *, parsed: bool = True):
+    """Decode one field out of a response payload. Returns None if the field lies
+    past the end of a short payload."""
+    if _byte_aligned(fs):
+        n = fs.bit_length // 8
+        if fs.byte_position >= len(data) and n:
+            return None
+        raw = bytes(data[fs.byte_position:fs.byte_position + n])
+        if len(raw) < n:
+            raw = raw.ljust(n, b"\x00")
+        if fs.data_type == "ascii":
+            return raw.decode("ascii", "replace").rstrip("\x00").strip()
+        if fs.data_type == "bytes":
+            return raw
+        value = int.from_bytes(raw, "big", signed=(fs.data_type == "int"))
+    elif fs.bit_length < 8 and fs.bit_position + fs.bit_length <= 8:
+        # sub-byte flag/enum within a single byte (all observed ODJ bit-fields)
+        if fs.byte_position >= len(data):
+            return None
+        value = (data[fs.byte_position] >> fs.bit_position) & ((1 << fs.bit_length) - 1)
+        if fs.data_type == "int" and value >> (fs.bit_length - 1):
+            value -= 1 << fs.bit_length
+    else:
+        raise OdjCodecError(
+            f"unsupported field layout: bit_position={fs.bit_position} "
+            f"bit_length={fs.bit_length} (multi-byte non-aligned not seen in ODJ)")
+    if parsed and fs.enum_map:
+        # A pure TRUE/FALSE enum decodes to a Python bool so graphs can compare a
+        # status against literal True/False (e.g. RUNNING vs in_progress=[True]).
+        if {k.upper() for k in fs.enum_map} == {"TRUE", "FALSE"}:
+            return bool(value)
+        inverse = {v: k for k, v in fs.enum_map.items()}
+        return inverse.get(value, value)
+    return value
+
+
+def decode_response(sub: SubSpec | None, data: bytes, *, parsed: bool = True) -> dict:
+    """Decode every output field of a SubSpec into a {name: value} dict."""
+    if sub is None:
+        return {}
+    return {name: decode_field(fs, data, parsed=parsed) for name, fs in sub.output.items()}
+
+
+def _coerce_scalar(fs: FieldSpec, value):
+    """Map an enum name back to its number; leave everything else as-is."""
+    if fs.enum_map and isinstance(value, str):
+        return fs.enum_map.get(value, value)
+    return value
+
+
+def encode_fields(fields: dict[str, FieldSpec], values: dict,
+                  input_size: int | None = None) -> bytes:
+    """Build a request payload from a {name: value} dict per a set of FieldSpecs:
+    byte-aligned fields are **big-endian** (the wire convention), sub-byte fields are
+    LSB-relative bit fields. Fields absent from ``values`` are zero-fill; the buffer is
+    at least ``input_size`` bytes.
+
+    Shared packer for everything that sends named UDS inputs -- routine start/stop
+    (SubSpec), WriteDataByIdentifier (SubSpec), and InputOutputControl (IoControlEntry)
+    -- so they all pack identically (and correctly) to the wire.
+    """
+    if not fields:
+        return b""
+    buf = bytearray(input_size or 0)
+
+    def _ensure(end: int) -> None:
+        if end > len(buf):
+            buf.extend(b"\x00" * (end - len(buf)))
+
+    for name, fs in fields.items():
+        if name not in values:
+            continue
+        value = _coerce_scalar(fs, values[name])
+        if _byte_aligned(fs):
+            n = fs.bit_length // 8
+            if fs.data_type == "ascii":
+                raw = str(value).encode("ascii", "replace")[:n].ljust(n, b"\x00")
+            elif fs.data_type == "bytes":
+                raw = bytes(value)[:n].ljust(n, b"\x00")
+            else:
+                raw = int(value).to_bytes(n, "big", signed=(fs.data_type == "int"))
+            _ensure(fs.byte_position + n)
+            buf[fs.byte_position:fs.byte_position + n] = raw
+        elif fs.bit_length < 8 and fs.bit_position + fs.bit_length <= 8:
+            _ensure(fs.byte_position + 1)
+            mask = ((1 << fs.bit_length) - 1) << fs.bit_position
+            buf[fs.byte_position] = (
+                (buf[fs.byte_position] & ~mask & 0xFF)
+                | ((int(value) << fs.bit_position) & mask))
+        else:
+            raise OdjCodecError(
+                f"unsupported input field layout for {name!r}: "
+                f"bit_position={fs.bit_position} bit_length={fs.bit_length}")
+    return bytes(buf)
+
+
+def encode_request(sub: SubSpec | None, values: dict) -> bytes:
+    """Build a request payload from a {name: value} dict per the SubSpec's input
+    fields (see ``encode_fields``). Fields absent from ``values`` are zero-fill."""
+    if sub is None:
+        return b""
+    return encode_fields(sub.input, values, sub.input_size)


### PR DESCRIPTION
Runs decompiled ODIN diagnostic procedures against a live bench or a mock
backend.

- **`scripts/odin_runner.py`** — the graph engine (`Engine`) with `MockBackend`
  and `BenchBackend`, UDS/ODX/CAN adapters, and a per-board interop store.
- **`scripts/odin_service.py` / `scripts/odin_coverage.py`** — procedure
  requirements + coverage analysis (which signals/nodes a procedure needs).
- **`scripts/odin_web.py`** — an aiohttp web UI over the runner.
- **`uds_local/datastore.py`** — board-keyed interop store (`odin_data.json`,
  gitignored).
- **`uds_local/odj_codec.py`** — ODJ request/response field codec.

Supporting changes:

- `config.py`: additive ODIN bundle path resolution (`ROOT`, `ODIN_BUNDLE`,
  `resolve_odin_bundle`) and multi-bus CAN channel helpers
  (`can_channel`/`canonical_bus`). `VEHICLE_CHANNEL` falls back to `TM3_CHANNEL`,
  so existing single-bus `.env` files keep working — the full
  `TM3_VEHICLE_CHANNEL` rename is left for a dedicated multi-bus PR.
- `uds_local/client.py`: add `UdsSession.read_dtcs` (ReadDTCInformation `0x19 02`).
- `tests/conftest.py`: put `scripts/` on `sys.path` so tests import the runner
  the same way the CLI does.
- Pin `py-uds==4.0.0` (same CI fix as #10).

Tests: full suite green (2405 passed, 6 skipped); ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
