### PR TITLE
refactor(config)!: rename TM3_CHANNEL -> TM3_VEHICLE_CHANNEL (multi-bus)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,9 @@
-# CAN interface
-TM3_CHANNEL=can0
+# CAN interface. TM3_VEHICLE_CHANNEL is the vehicle bus and the default --channel
+# for every tool. Party/charge are optional — set them only on a multi-bus bench;
+# tools fall back to the vehicle bus when a bus has no channel configured.
+TM3_VEHICLE_CHANNEL=can0
+# TM3_PARTY_CHANNEL=can1
+# TM3_CHARGE_CHANNEL=can2
 TM3_INTERFACE=socketcan
 # TM3_BITRATE=500000
 

--- a/README.md
+++ b/README.md
@@ -40,12 +40,14 @@ Copy the example config and open it in a text editor:
 cp .env.example .env
 ```
 
-Set `TM3_CHANNEL` to your CAN interface name and `TM3_INTERFACE` to your adapter's driver. The defaults work for a standard Linux SocketCAN setup:
+Set `TM3_VEHICLE_CHANNEL` to your CAN interface name and `TM3_INTERFACE` to your adapter's driver. The defaults work for a standard Linux SocketCAN setup:
 
 ```bash
-TM3_CHANNEL=can0       # your interface name — check with: ip link show type can
+TM3_VEHICLE_CHANNEL=can0   # your interface name — check with: ip link show type can
 TM3_INTERFACE=socketcan
 ```
+
+`TM3_VEHICLE_CHANNEL` is the vehicle bus and the default channel for every tool. On a multi-bus bench you can also set `TM3_PARTY_CHANNEL` and `TM3_CHARGE_CHANNEL`; tools fall back to the vehicle bus when a bus has no channel configured.
 
 Bring the interface up before running any tool (replace `can0` and `500000` with your interface and bitrate):
 
@@ -60,7 +62,7 @@ To use a virtual interface for testing without hardware:
 sudo modprobe vcan
 sudo ip link add dev vcan0 type vcan
 sudo ip link set vcan0 up
-# then set TM3_CHANNEL=vcan0 in .env
+# then set TM3_VEHICLE_CHANNEL=vcan0 in .env
 ```
 
 ### 3. Firmware dump (optional)

--- a/config.py
+++ b/config.py
@@ -164,13 +164,10 @@ COMPACT_DBS: dict[str, Path] = compact_dbs()
 # CAN channels — the three Model 3 buses
 # ---------------------------------------------------------------------------
 # Downstream tools (odin_runner, ...) pick the right channel per bus.
-# TM3_VEHICLE_CHANNEL is the vehicle bus; it falls back to the generic
-# TM3_CHANNEL so existing single-bus .env files keep working. Party/charge are
-# None unless configured (a simple bench has only the vehicle bus, and callers
-# fall back to it).
-VEHICLE_CHANNEL: str | None = (
-    os.environ.get("TM3_VEHICLE_CHANNEL") or os.environ.get("TM3_CHANNEL")
-)
+# TM3_VEHICLE_CHANNEL is the vehicle bus (and the default --channel for every
+# tool). Party/charge are None unless configured (a simple bench has only the
+# vehicle bus, and callers fall back to it).
+VEHICLE_CHANNEL: str | None = os.environ.get("TM3_VEHICLE_CHANNEL")
 PARTY_CHANNEL:   str | None = os.environ.get("TM3_PARTY_CHANNEL")
 CHARGE_CHANNEL:  str | None = os.environ.get("TM3_CHARGE_CHANNEL")
 
@@ -212,7 +209,7 @@ def can_channel(bus: str | None = None) -> str | None:
 # ---------------------------------------------------------------------------
 
 _ENV_MAP = {
-    "channel":       ("TM3_CHANNEL",       str,  "vcan0"),
+    "channel":       ("TM3_VEHICLE_CHANNEL", str, "vcan0"),
     "interface":     ("TM3_INTERFACE",      str,  "socketcan"),
     "bitrate":       ("TM3_BITRATE",        int,  None),
     "force":         ("TM3_DFU_FORCE",      bool, None),

--- a/docs/dfu.md
+++ b/docs/dfu.md
@@ -14,7 +14,7 @@ python dfu.py --node PCS --channel vcan0 --artifacts ~/seed_artifacts_v2 --force
 | Flag                | Default             | Description                             |
 | ------------------- | ------------------- | --------------------------------------- |
 | `--node`, `-n`      | —                   | ECU node name                           |
-| `--channel`, `-c`   | `TM3_CHANNEL`       | CAN interface                           |
+| `--channel`, `-c`   | `TM3_VEHICLE_CHANNEL` | CAN interface                         |
 | `--interface`, `-i` | `TM3_INTERFACE`     | python-can interface type               |
 | `--artifacts`, `-a` | `TM3_ARTIFACTS_DIR` | Path to `seed_artifacts_v2` directory   |
 | `--force`           | —                   | Proceed despite BHX identity mismatches |

--- a/docs/ghidra_c28x_loading.md
+++ b/docs/ghidra_c28x_loading.md
@@ -125,7 +125,7 @@ python tm3diag.py --node PCS
 #   board-parts     → reads part/serial DIDs 0xF012–0xF015, 0xF030/0xF031
 ```
 
-(The CAN channel and artifacts directory come from `TM3_CHANNEL` and `TM3_ARTIFACTS_DIR` in
+(The CAN channel and artifacts directory come from `TM3_VEHICLE_CHANNEL` and `TM3_ARTIFACTS_DIR` in
 your `.env`, so you don't need to pass `--channel` or `--artifacts`.)
 
 `board-parts` returns the ECU's hardware part/assembly numbers; match those against the

--- a/docs/tm3diag.md
+++ b/docs/tm3diag.md
@@ -13,7 +13,7 @@ python tm3diag.py --node PCS --channel vcan0 --artifacts ~/seed_artifacts_v2
 | Flag                | Default             | Description                                                       |
 | ------------------- | ------------------- | ----------------------------------------------------------------- |
 | `--node`, `-n`      | —                   | ECU node name. Opens pre-connection menu if omitted.              |
-| `--channel`, `-c`   | `TM3_CHANNEL`       | CAN interface                                                     |
+| `--channel`, `-c`   | `TM3_VEHICLE_CHANNEL` | CAN interface                                                   |
 | `--interface`, `-i` | `TM3_INTERFACE`     | python-can interface type                                         |
 | `--artifacts`, `-a` | `TM3_ARTIFACTS_DIR` | Path to `seed_artifacts_v2` (needed for DFU; prompted if missing) |
 

--- a/docs/tm3uds.md
+++ b/docs/tm3uds.md
@@ -31,5 +31,5 @@ python tm3uds.py --node PCS --channel vcan0 reset
 | Flag                | Default         | Description                             |
 | ------------------- | --------------- | --------------------------------------- |
 | `--node`, `-n`      | —               | ECU node name (e.g. `PCS`, `CP`, `RCM`) |
-| `--channel`, `-c`   | `TM3_CHANNEL`   | CAN interface                           |
+| `--channel`, `-c`   | `TM3_VEHICLE_CHANNEL` | CAN interface                     |
 | `--interface`, `-i` | `TM3_INTERFACE` | python-can interface type               |


### PR DESCRIPTION
Standardizes CAN channel configuration on the three Model 3 buses.

- The vehicle bus is now **`TM3_VEHICLE_CHANNEL`** — the default `--channel` for
  every tool.
- Optional **`TM3_PARTY_CHANNEL`** / **`TM3_CHARGE_CHANNEL`** name the party and
  charge buses; tools fall back to the vehicle bus when a bus has no channel
  configured (`config.can_channel` / `canonical_bus`, added in #11).

**BREAKING:** `TM3_CHANNEL` is no longer read. Update your `.env`:

```diff
-TM3_CHANNEL=can0
+TM3_VEHICLE_CHANNEL=can0
```

Updates `config.py`, `.env.example`, `README.md`, and the tm3uds / tm3diag /
dfu / ghidra_c28x_loading docs. Full suite green; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
