### PR TITLE
chore: scrub docs/private path references from the public tree

### DIFF
--- a/docs/ghidra_c28x_loading.md
+++ b/docs/ghidra_c28x_loading.md
@@ -175,8 +175,7 @@ each word with its bytes reversed relative to the instruction stream. Read raw, 
 compiled-function prologue `MOVL *SP++` ×3 (`b2bd aabd a2bd`) appears **0** times; read
 byte-swapped it appears 67–329× per image, and `LRETR` density jumps to ~7/KB (real-code
 density). This is a property of the Tesla F28377D image format, so it applies to **every**
-F28377D-based module — DIR, PMR, PCS, and others — across all firmware eras. (See
-`docs/private/c28x-ghidra-tesla/BYTESWAP-BREAKTHROUGH.md` for the full evidence.)
+F28377D-based module — DIR, PMR, PCS, and others — across all firmware eras.
 
 ---
 
@@ -282,8 +281,7 @@ So don't go hunting for a single "main" entry. Instead, work outward from what S
 gives you: call targets, prologue-seeded functions, and string/MMIO cross-references. For the
 inverter, the CAN driver and its RX-filter mailbox tables are the most productive anchors
 (CAN is PMR-side; the DIR receives commands over the `0x3FC00` IPC message RAM). Reading flash
-sector A or a full live image needs hardware (JTAG via the DCSM, or chip-off) — see
-`docs/private/c28x-ghidra-tesla/docs/GETTING-THE-ENTRY.md`.
+sector A or a full live image needs hardware (JTAG via the DCSM, or chip-off).
 
 ---
 
@@ -323,6 +321,3 @@ Prologue byte-search for manual seeding: `bd b2 bd aa bd a2`.
 - [tm3diag.md](tm3diag.md) — the interactive terminal; `board-parts` reads the part DIDs that key into the metadata map.
 - [bhx.md](bhx.md) — the BHX container format and `bhx.py`.
 - `deploy/seed_artifacts_v2/signed_metadata_map.tsv` — the firmware index (part# → file → config tags).
-- `docs/private/c28x-ghidra-tesla/BYTESWAP-BREAKTHROUGH.md` — why the byte-swap is needed.
-- `docs/private/c28x-ghidra-tesla/docs/GETTING-THE-ENTRY.md` — the missing sector-A entry stub.
-- `ghidra-tms320c28x/docs/BUILDING.machine-specific.md` — building/installing the processor module.

--- a/scripts/c28x/c28x_loadimg.py
+++ b/scripts/c28x/c28x_loadimg.py
@@ -16,7 +16,7 @@ This tool runs in two modes:
              record format can be pinned down by eye / by cross-image diff.
   build    — (once the format is confirmed) emit the reassembled flat runtime image.
 
-Header format (reverse-engineered; see docs/private/.../tesla_0x0900_header.md):
+Header format (reverse-engineered):
   u32[0] magic 0x0900 (low) | version<<16 (0x1c=P28)
   u32[1] image type/seq (pmrbl=1, pmrbu=2)
   u32[2..3] signature/id

--- a/scripts/odin_runner.py
+++ b/scripts/odin_runner.py
@@ -6,7 +6,7 @@ Runs the REAL ODIN diagnostic graphs from the firmware bundle
 odin-engine + web UI. Node-type inventory across the bundle is 181 types, but
 only 5 modules touch hardware (uds / odx / can / cid / vehiclecontrols); the
 other ~90% (networks / control / logic / dicts / reporting / ...) is pure
-compute that runs unchanged. See docs/private/odin-resolver-cal-and-inverter-swap.md.
+compute that runs unchanged.
 
 Execution model (as read out of the graphs):
   * CONTROL flow is push: a node's control-OUTPUT port (run/done/passed/if_true/
@@ -112,7 +112,7 @@ class RunResult:
 
 # =====================================================================================
 # CID emulation (cid.* nodes): a read-your-writes data-value store + a read-only
-# view of a firmware-dump rootfs. See docs/private/odin-runner-plan.md (Step 5).
+# view of a firmware-dump rootfs.
 # =====================================================================================
 # Sensible bench defaults for CID data-values graphs read back after (or without)
 # a SetDataValue. Values are strings, matching the CID data-value wire type.


### PR DESCRIPTION
Several comments and docs pointed at `docs/private/…` files (the gitignored RE
tree), which don't exist in the public repo. This removes the dangling
references; the surrounding explanations stay.

- `scripts/odin_runner.py` (2)
- `scripts/c28x/c28x_loadimg.py` (1)
- `docs/ghidra_c28x_loading.md` (4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
