### PR TITLE
feat(dbc): rich Model 3 ETH DBC from the MCU CAN catalog

### DIFF
--- a/candata_to_dbc.py
+++ b/candata_to_dbc.py
@@ -1,0 +1,411 @@
+"""Build a rich Model 3 ETH DBC from the MCU UI CAN catalog.
+
+The infotainment ``libQtCarCANData.so`` embeds the *complete* vehicle signal
+catalog -- message IDs, DLCs, cycle times, signal names, units and enum value
+tables -- but not the numeric bit-layout (start bit / width / scale / offset).
+The per-revision ``Model3_ETH.compact.json`` has the bit-layout, but Tesla
+strips it down every release (2022.45.15: 140 messages in compact.json vs 446
+in the .so).
+
+This tool marries the two:
+
+    catalog (topology + units + enums)   <-  libQtCarCANData.so   (rich, full)
+    bit-layout (start/width/scale/off)    <-  compact.json donor(s) (authoritative)
+
+Signals present in the .so but with no layout donor can't be decoded, so they
+land in a coverage report rather than the DBC.
+
+Usage:
+    # just dump the .so catalog as compact-schema JSON
+    python candata_to_dbc.py extract libQtCarCANData.so -o catalog.json
+
+    # rich DBC: .so catalog overlaid with compact.json layout
+    python candata_to_dbc.py dbc libQtCarCANData.so \
+        --compact Model3_ETH.compact.json[.bin] [--compact older.json ...] \
+        -o Model3_ETH.rich.dbc --report gaps.txt
+
+Donors are consulted in the order given (first match wins), so list the
+same-revision compact.json first, then older/newer ones to recover layout for
+signals the current revision dropped.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import compact_to_dbc
+import so_candata
+from decode_bin import load_json
+
+_LAYOUT_KEYS = ("start_position", "width")
+
+# Extraction-dir suffixes to strip when deriving a rev from the firmware root.
+_ROOT_SUFFIXES = (".ice.extracted", ".extracted", ".model3", ".modely")
+
+
+def _rev_from_lib(lib: Path, root: Path | None = None) -> str:
+    """Derive a firmware revision token from the firmware root directory name.
+
+    The lib lives at ``<root>/usr/tesla/UI/lib/libQtCarCANData.so*`` so the root
+    is the path component just above ``usr/``. The extraction suffix (e.g.
+    ``.ice.extracted`` or ``.model3``) is stripped, yielding tokens like
+    ``2022.45.15`` or ``2020.8.1-9-ae1963092f``.
+    """
+    if root is None:
+        parts = Path(lib).resolve().parts
+        cut = next((parts.index(m) for m in ("usr", "opt") if m in parts), None)
+        root = Path(*parts[:cut]) if cut else Path(lib).resolve().parent
+    name = Path(root).name
+    for suf in _ROOT_SUFFIXES:
+        if name.endswith(suf):
+            name = name[:-len(suf)]
+            break
+    return name or "unknown"
+
+
+def _has_layout(sig: dict) -> bool:
+    return all(k in sig for k in _LAYOUT_KEYS)
+
+
+def _alert_signal_index(alerts: dict) -> dict[str, list[str]]:
+    """Map each logged CAN signal (ETH_ stripped) -> [alert names that log it]."""
+    idx: dict[str, list[str]] = {}
+    for name, a in alerts.items():
+        for s in a.get("log_signals", []):
+            key = s[4:] if s.startswith("ETH_") else s
+            idx.setdefault(key, []).append(name)
+    return idx
+
+
+def _annotate_alerts(db: dict, sigidx: dict[str, list[str]], alerts: dict) -> int:
+    """Attach a ``comment`` to each DBC signal an alert logs (-> CM_ SG_)."""
+    n = 0
+    for m in db["messages"].values():
+        for sname, sig in m["signals"].items():
+            names = sigidx.get(sname)
+            if not names:
+                continue
+            names = sorted(set(names))
+            comment = "alert: " + "; ".join(names)
+            if len(names) == 1:
+                desc = alerts.get(names[0], {}).get("description")
+                if desc:
+                    comment += f" -- {desc}"
+            sig["comment"] = comment[:480]
+            n += 1
+    return n
+
+
+def _merge_signal(so_sig: dict, layout: dict) -> dict:
+    """Overlay .so enrichment (units + enums) onto a donor layout signal."""
+    out = dict(layout)
+    if so_sig.get("units"):
+        out["units"] = so_sig["units"]
+    vd = dict(layout.get("value_description") or {})
+    vd.update(so_sig.get("value_description") or {})
+    if vd:
+        out["value_description"] = vd
+    if so_sig.get("value_table_name"):
+        out["value_table_name"] = so_sig["value_table_name"]
+    return out
+
+
+def _layout_signals(donor_msg: dict) -> dict[str, dict]:
+    """Signals of a donor message that carry a usable bit-layout."""
+    return {n: s for n, s in donor_msg.get("signals", {}).items()
+            if _has_layout(s)}
+
+
+def _index_donor_messages(donors: list[dict]):
+    """Index donor messages by name and by id, each in donor-priority order.
+
+    Values are lists of (donor_index, donor_msg) so we can pick a single
+    self-consistent donor message per CAN message (mixing bit-layouts from
+    different firmware revisions inside one message causes overlaps -- Tesla
+    repurposes bits across releases).
+    """
+    by_name: dict[str, list[tuple[int, dict]]] = {}
+    by_id: dict[int, list[tuple[int, dict]]] = {}
+    for idx, db in enumerate(donors):
+        for mname, m in db.get("messages", {}).items():
+            by_name.setdefault(mname, []).append((idx, m))
+            mid = m.get("message_id")
+            if mid is not None:
+                by_id.setdefault(mid, []).append((idx, m))
+    return by_name, by_id
+
+
+def _choose_donor(cands: list[tuple[int, dict]], prefer_order: bool):
+    """Pick one donor message: richest layout (default) or first (prefer_order).
+
+    ``cands`` is in donor-priority order, so ``max`` breaks ties toward the
+    earliest (highest-priority) donor.
+    """
+    usable = [(i, m) for i, m in cands if _layout_signals(m)]
+    if not usable:
+        return None
+    if prefer_order:
+        return usable[0]
+    return max(usable, key=lambda im: len(_layout_signals(im[1])))
+
+
+def enrich(cat: so_candata.SoCatalog, donors: list[dict], *,
+           prefer_order: bool = False):
+    """Merge a .so catalog with compact.json donors.
+
+    Layout for each message is taken from a *single* donor (the richest, or the
+    highest-priority when ``prefer_order``) so the result stays internally
+    consistent. The .so overlays units and enum tables. Returns
+    ``(enriched_db, report)`` in compact-schema form.
+    """
+    by_name, by_id = _index_donor_messages(donors)
+    donor_labels = [db.get("_label") or db.get("version") or f"donor{idx}"
+                    for idx, db in enumerate(donors)]
+
+    messages: dict[str, dict] = {}
+    gaps: list[dict] = []
+    sources: list[dict] = []
+    n_enriched = 0
+
+    def build(mname: str, m_so: dict | None, cands: list[tuple[int, dict]]):
+        nonlocal n_enriched
+        chosen = _choose_donor(cands, prefer_order)
+        out_sigs: dict[str, dict] = {}
+        donor_len = 0
+        so_sigs = (m_so or {}).get("signals", {})
+        if chosen:
+            didx, dmsg = chosen
+            donor_len = dmsg.get("length_bytes", 0)
+            for sname, layout in _layout_signals(dmsg).items():
+                so_sig = so_sigs.get(sname, {})
+                out_sigs[sname] = _merge_signal(so_sig, layout)
+                if sname in so_sigs:
+                    n_enriched += 1
+            sources.append({"message": mname,
+                            "donor": donor_labels[didx],
+                            "signals": len(out_sigs)})
+        # .so-only signals with no layout anywhere -> reported as a gap.
+        for sname in so_sigs:
+            if sname not in out_sigs:
+                gaps.append({"message": mname,
+                             "message_id": (m_so or {}).get("message_id", 0),
+                             "signal": sname})
+        mid = (m_so or {}).get("message_id")
+        if mid is None:
+            mid = chosen[1].get("message_id", 0) if chosen else 0
+        so_len = (m_so or {}).get("length_bytes") or 0
+        length = max(so_len, donor_len, 8)
+        node = (m_so or {}).get("originNode") \
+            or (chosen[1].get("originNode") if chosen else None) \
+            or mname.split("_", 1)[0]
+        return {
+            "message_id": mid,
+            "length_bytes": length,
+            "cycle_time": (m_so or {}).get("cycle_time")
+            or (chosen[1].get("cycle_time", 0) if chosen else 0),
+            "originNode": node,
+            "senders": [node],
+            "signals": out_sigs,
+        }
+
+    # Spine: every message in the .so catalog.
+    for mname, m_so in cat.messages.items():
+        cands = by_name.get(mname) or by_id.get(m_so["message_id"]) or []
+        messages[mname] = build(mname, m_so, cands)
+
+    # Messages a donor knows but the .so does not (only if layout exists).
+    donor_only = 0
+    for mname, cands in by_name.items():
+        if mname in messages or _choose_donor(cands, prefer_order) is None:
+            continue
+        messages[mname] = build(mname, None, cands)
+        donor_only += 1
+
+    enriched_db = {
+        "product": "Model3",
+        "version": f"rich:{cat.lib}",
+        "busMetadata": {cat.bus: {"messageCount": len(messages)}},
+        "messages": messages,
+    }
+    report = {
+        "lib": cat.lib,
+        "bus": cat.bus,
+        "donors": donor_labels,
+        "so_messages": len(cat.messages),
+        "so_signals": cat.signal_count,
+        "signals_enriched": n_enriched,
+        "signals_gapped": len(gaps),
+        "donor_only_messages": donor_only,
+        "sources": sources,
+        "gaps": gaps,
+    }
+    return enriched_db, report
+
+
+def _write_report(report: dict, path: Path) -> None:
+    lines = [
+        f"# ETH DBC coverage report -- {report['lib']} (bus {report['bus']})",
+        f"# donors (priority order): {', '.join(report['donors'])}",
+        "",
+        f"messages in .so catalog : {report['so_messages']}",
+        f"signals in .so catalog  : {report['so_signals']}",
+        f"signals with layout     : {report['signals_enriched']}",
+        f"signals WITHOUT layout  : {report['signals_gapped']}",
+        f"donor-only messages     : {report['donor_only_messages']}",
+        "",
+        "## layout source per message (message -> donor : #signals):",
+    ]
+    primary = report["donors"][0] if report["donors"] else None
+    borrowed = [s for s in report["sources"] if s["donor"] != primary]
+    for s in sorted(report["sources"], key=lambda s: s["message"]):
+        flag = "  <- non-primary" if s["donor"] != primary else ""
+        lines.append(f"    {s['message']} -> {s['donor']} : {s['signals']}{flag}")
+    lines.append("")
+    lines.append(f"## {len(borrowed)} messages took layout from a non-primary "
+                 "(cross-revision) donor")
+    lines.append("")
+    lines.append("## signals missing a layout donor (undecodable):")
+    by_msg: dict[str, list[str]] = {}
+    for g in report["gaps"]:
+        by_msg.setdefault(f"{g['message']} (0x{g['message_id']:X})", []).append(
+            g["signal"])
+    for mkey in sorted(by_msg):
+        lines.append(f"\n{mkey}")
+        for s in sorted(by_msg[mkey]):
+            lines.append(f"    {s}")
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _load_donors(paths: list[Path]) -> list[dict]:
+    donors = []
+    for p in paths:
+        db = load_json(p)
+        db["_label"] = _rev_from_lib(Path(p))
+        n = len(db.get("messages", {}))
+        print(f"  donor {db['_label']} ({p.name}): {n} messages",
+              file=sys.stderr)
+        donors.append(db)
+    return donors
+
+
+_DEFAULT_LIB_REL = "usr/tesla/UI/lib/libQtCarCANData.so"
+
+
+def _resolve_lib(args) -> tuple[Path, Path | None]:
+    """Return (lib_path, root_hint), defaulting the lib from config.ROOT."""
+    import config as _cfg
+    root = Path(args.root).expanduser() if args.root else _cfg.ROOT
+    if args.lib:
+        return Path(args.lib), root
+    if root is None:
+        sys.exit("no lib given and config.ROOT (TM3_ROOT) is unset "
+                 "(pass the .so path, --root, or set TM3_ROOT in .env)")
+    return root / _DEFAULT_LIB_REL, root
+
+
+def _resolve_rev(args, lib: Path, root: Path | None) -> str:
+    import config as _cfg
+    return args.rev or _cfg.FW_VERSION or _rev_from_lib(lib, root)
+
+
+def cmd_extract(args) -> None:
+    lib, root = _resolve_lib(args)
+    rev = _resolve_rev(args, lib, root)
+    cat = so_candata.extract_catalog(lib, bus=args.bus)
+    print(f"{cat.lib}: rev={rev} bus={cat.bus} messages={len(cat.messages)} "
+          f"signals={cat.signal_count} value_tables={cat.value_table_count}",
+          file=sys.stderr)
+    db = so_candata.to_compact_dict(cat, product=args.product)
+    db["version"] = rev
+    out = args.out or Path(f"{args.product}_{cat.bus}.{rev}.catalog.json")
+    out.write_text(json.dumps(db, indent=2, sort_keys=True))
+    print(f"wrote {out}")
+
+
+def cmd_dbc(args) -> None:
+    lib, root = _resolve_lib(args)
+    rev = _resolve_rev(args, lib, root)
+    cat = so_candata.extract_catalog(lib, bus=args.bus)
+    print(f"catalog: rev={rev} {len(cat.messages)} messages / "
+          f"{cat.signal_count} signals", file=sys.stderr)
+    if not args.compact:
+        import config as _cfg
+        if _cfg.ETH_COMPACT is None:
+            sys.exit("no --compact given and config.ETH_COMPACT is unset "
+                     "(set TM3_ROOT or pass --compact)")
+        args.compact = [_cfg.ETH_COMPACT]
+    donors = _load_donors(args.compact)
+    enriched_db, report = enrich(cat, donors, prefer_order=args.prefer_order)
+    enriched_db["dbc_version"] = rev
+
+    # Cross-link alerts: annotate each logged signal with the alert(s) that log it.
+    if not args.no_alerts:
+        alib = args.alerts or (lib.parent / "libQtCarAlerts.so")
+        if Path(alib).exists():
+            import so_alerts
+            acat = so_alerts.extract_alerts(alib)
+            n = _annotate_alerts(enriched_db,
+                                 _alert_signal_index(acat.alerts), acat.alerts)
+            print(f"alerts: {Path(alib).name} -> annotated {n} signals",
+                  file=sys.stderr)
+        elif args.alerts:
+            print(f"alerts: {alib} not found, skipping", file=sys.stderr)
+
+    out = args.out or Path(f"{args.product}_{cat.bus}.{rev}.dbc")
+    compact_to_dbc.convert_db(enriched_db, out)
+    print(f"enriched: {report['signals_enriched']} signals with layout, "
+          f"{report['signals_gapped']} without", file=sys.stderr)
+    if args.report:
+        _write_report(report, args.report)
+        print(f"wrote report {args.report}")
+    if args.json:
+        args.json.write_text(json.dumps(enriched_db, indent=2, sort_keys=True))
+        print(f"wrote enriched json {args.json}")
+
+
+def main(argv: list[str] | None = None) -> None:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--product", default="Model3", help="product name (default Model3)")
+    sub = ap.add_subparsers(dest="cmd", required=True)
+
+    pe = sub.add_parser("extract", help="dump the .so catalog as compact JSON")
+    pe.add_argument("lib", type=Path, nargs="?",
+                    help="libQtCarCANData.so (default: from config.ROOT)")
+    pe.add_argument("--root", help="firmware extraction root (default: TM3_ROOT)")
+    pe.add_argument("--rev", help="firmware rev label (default: from root name)")
+    pe.add_argument("--bus", help="override bus name (default from CANBusList)")
+    pe.add_argument("-o", "--out", type=Path, help="output JSON path")
+    pe.set_defaults(func=cmd_extract)
+
+    pd = sub.add_parser("dbc", help="build a rich DBC (.so + compact.json)")
+    pd.add_argument("lib", type=Path, nargs="?",
+                    help="libQtCarCANData.so (default: from config.ROOT)")
+    pd.add_argument("--root", help="firmware extraction root (default: TM3_ROOT)")
+    pd.add_argument("--rev", help="firmware rev label (default: from root name)")
+    pd.add_argument("--compact", type=Path, action="append", default=[],
+                    help="compact.json donor (repeatable; first match wins)")
+    pd.add_argument("--bus", help="override bus name")
+    pd.add_argument("-o", "--out", type=Path, help="output DBC path")
+    pd.add_argument("--report", type=Path, help="write coverage/gap report")
+    pd.add_argument("--json", type=Path, help="also write enriched compact JSON")
+    pd.add_argument("--prefer-order", action="store_true",
+                    help="per message, take layout from the first donor that "
+                         "has it (current-rev fidelity) instead of the richest "
+                         "donor (max coverage, the default)")
+    pd.add_argument("--alerts", type=Path,
+                    help="libQtCarAlerts.so for alert<->signal CM_ annotations "
+                         "(default: sibling of the CAN lib)")
+    pd.add_argument("--no-alerts", action="store_true",
+                    help="skip alert->signal CM_ annotations")
+    pd.set_defaults(func=cmd_dbc)
+
+    args = ap.parse_args(argv)
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/compact_to_dbc.py
+++ b/compact_to_dbc.py
@@ -51,13 +51,17 @@ def _sanitize(name: str) -> str:
 
 
 def convert(src: Path, dst: Path) -> None:
-    db = load_json(src)
+    """Convert a compact.json file at *src* to a DBC at *dst*."""
+    convert_db(load_json(src), dst)
 
+
+def convert_db(db: dict, dst: Path) -> None:
+    """Convert an in-memory compact-schema *db* dict to a DBC at *dst*."""
     messages = db["messages"]
 
     lines: list[str] = []
 
-    lines.append('VERSION ""')
+    lines.append(f'VERSION "{db.get("dbc_version", "")}"')
     lines.append("")
     lines.append("NS_ :")
     lines.append("")
@@ -102,6 +106,8 @@ def convert(src: Path, dst: Path) -> None:
     # Collect value_descriptions to emit after all messages
     val_defs: list[tuple[int, str, dict]] = []  # (msg_id, sig_name, value_description)
 
+    sig_comments: list[tuple[int, str, str]] = []  # (msg_id, sig_name, comment)
+
     for msg_name, msg in sorted(messages.items(), key=lambda kv: kv[1]["message_id"]):
         msg_id = msg["message_id"]
         length = msg.get("length_bytes", 8)
@@ -138,10 +144,18 @@ def convert(src: Path, dst: Path) -> None:
             if vd:
                 val_defs.append((msg_id, sig_name, vd))
 
+            comment = sig.get("comment")
+            if comment:
+                sig_comments.append((msg_id, sig_name, comment))
+
         lines.append("")
 
-    # ---- Signal comments (units already in SG_, add any extra description) ----
-    # (nothing extra in this schema)
+    # ---- Signal comments (CM_ SG_) ----
+    if sig_comments:
+        for msg_id, sig_name, comment in sig_comments:
+            esc = comment.replace("\\", "\\\\").replace('"', '\\"')
+            lines.append(f'CM_ SG_ {msg_id} {_sanitize(sig_name)} "{esc}";')
+        lines.append("")
 
     # ---- Value definitions ----
     if val_defs:

--- a/so_candata.py
+++ b/so_candata.py
@@ -1,0 +1,312 @@
+"""Extract Tesla's CAN/ETH signal catalog from the MCU UI shared objects.
+
+The infotainment UI stack ships ``libQtCarCANData.so``, which embeds the full
+vehicle signal catalog as relocated data tables (no debug symbols needed --
+the tables are *exported* objects):
+
+    CANBusList          -> one "ETH" pseudo-bus descriptor, count + message array
+    ETH_messages        -> array of 48-byte message descriptors
+    ETH_<msg>_signals   -> per-message array of 40-byte signal descriptors
+    Diag_<sig>_map      -> per-signal value->label enum tables
+
+The catalog is *richer* than the per-revision ``Model3_ETH.compact.json`` (the
+2022.45.15 build exposes 446 messages here vs 140 in compact.json), but it does
+NOT carry the numeric bit-layout (start bit / width / scale / offset). Pair it
+with :mod:`candata_to_dbc` to overlay layout from a compact.json donor.
+
+Struct layouts (x86-64 LSB, reversed from the 2022.45.15 build and validated
+against known Model 3 CAN IDs, e.g. BMS_kwhCounter == 0x3D2):
+
+    message (48 bytes)              signal (40 bytes)
+      +0x00  char*  name             +0x00  char*  name
+      +0x08  u32    can_id           +0x08  u32    key (name hash)
+      +0x0c  u32    dlc              +0x0c  u32    (pad)
+      +0x10  u32    cycle_time_ms    +0x10  char*  units ("" if none)
+      +0x14  u32    signal_count     +0x18  msg*   parent (into ETH_messages)
+      +0x18  u32    mux/flags        +0x20  map*   value map (Diag_*, 0 if none)
+      +0x20  sig*   signals
+      +0x28  bus*   bus (CANBusList)
+
+    value map: flat [u32 value][char* label] pairs, terminated by
+               (0xffffffff, "").
+"""
+
+from __future__ import annotations
+
+import struct
+from dataclasses import dataclass, field
+from pathlib import Path
+
+MSG_STRIDE = 48
+SIG_STRIDE = 40
+MAP_STRIDE = 16
+
+# ELF relocation types we care about (x86-64)
+_R_X86_64_64 = 1
+_R_X86_64_GLOB_DAT = 6
+_R_X86_64_JUMP_SLOT = 7
+_R_X86_64_RELATIVE = 8
+
+
+class ElfImage:
+    """Minimal read-only ELF64 reader with relocation resolution.
+
+    Pure-stdlib so it runs anywhere the rest of tm3diag does. Only the pieces
+    needed to walk relocated data tables are implemented.
+    """
+
+    def __init__(self, path: str | Path):
+        self.path = Path(path)
+        self.d = self.path.read_bytes()
+        d = self.d
+        if d[:4] != b"\x7fELF" or d[4] != 2:
+            raise ValueError(f"{path}: not an ELF64 image")
+        (self.e_type, self.e_machine, _ev, _entry, _phoff, self.e_shoff,
+         _flags, _ehsize, _phes, _phn, self.e_shentsize, self.e_shnum,
+         self.e_shstrndx) = struct.unpack_from("<HHIQQQIHHHHHH", d, 16)
+
+        self.sections: list[dict] = []
+        for i in range(self.e_shnum):
+            off = self.e_shoff + i * self.e_shentsize
+            (name, typ, flags, addr, offset, size, link, info, _align,
+             entsize) = struct.unpack_from("<IIQQQQIIQQ", d, off)
+            self.sections.append({"name": name, "type": typ, "flags": flags,
+                                  "addr": addr, "offset": offset, "size": size,
+                                  "link": link, "info": info,
+                                  "entsize": entsize})
+        shstr = self.sections[self.e_shstrndx]
+        for s in self.sections:
+            s["n"] = self._cstr_at(shstr["offset"] + s["name"])
+        self.by_name = {s["n"]: s for s in self.sections}
+        # Sections that occupy virtual address space (for vaddr -> file off).
+        self._alloc = [s for s in self.sections if s["addr"] and s["size"]]
+
+        self.syms: dict[str, dict] = {}     # name -> {value, size}
+        self._symlist: list[tuple[str, int]] = []  # dynsym order (for relocs)
+        self._load_syms(".dynsym", ".dynstr")
+        self._load_syms(".symtab", ".strtab")  # usually absent (stripped)
+        # addr -> (name, size) for the first OBJECT/func symbol at each start.
+        self._by_addr: dict[int, tuple[str, int]] = {}
+        for nm, s in self.syms.items():
+            self._by_addr.setdefault(s["value"], (nm, s["size"]))
+
+        self.reloc: dict[int, tuple] = {}   # r_offset -> ('rel', t)|('sym', n, a)
+        self._load_rela(".rela.dyn")
+        self._load_rela(".rela.plt")
+
+    # -- raw helpers ----------------------------------------------------------
+    def _cstr_at(self, off: int, maxlen: int = 4096) -> str:
+        e = self.d.find(b"\x00", off, off + maxlen)
+        if e < 0:
+            e = off + maxlen
+        return self.d[off:e].decode("latin1")
+
+    def _load_syms(self, symsec: str, strsec: str) -> None:
+        if symsec not in self.by_name or strsec not in self.by_name:
+            return
+        ss, st, d = self.by_name[symsec], self.by_name[strsec], self.d
+        for i in range(ss["size"] // 24):
+            o = ss["offset"] + i * 24
+            name, _info, _other, _shndx, value, size = struct.unpack_from(
+                "<IBBHQQ", d, o)
+            nm = self._cstr_at(st["offset"] + name)
+            self._symlist.append((nm, value))
+            if nm and nm not in self.syms:
+                self.syms[nm] = {"value": value, "size": size}
+
+    def _load_rela(self, sec: str) -> None:
+        if sec not in self.by_name:
+            return
+        rs, d = self.by_name[sec], self.d
+        for i in range(rs["size"] // 24):
+            r_offset, r_info, r_addend = struct.unpack_from(
+                "<QQq", d, rs["offset"] + i * 24)
+            r_type = r_info & 0xFFFFFFFF
+            r_sym = r_info >> 32
+            if r_type == _R_X86_64_RELATIVE:
+                self.reloc[r_offset] = ("rel", r_addend)
+            elif r_type in (_R_X86_64_64, _R_X86_64_GLOB_DAT,
+                            _R_X86_64_JUMP_SLOT):
+                nm = self._symlist[r_sym][0] if r_sym < len(self._symlist) else ""
+                self.reloc[r_offset] = ("sym", nm, r_addend)
+
+    def v2o(self, addr: int) -> int | None:
+        for s in self._alloc:
+            if s["addr"] <= addr < s["addr"] + s["size"]:
+                if s["type"] == 8:  # SHT_NOBITS (.bss) has no file bytes
+                    return None
+                return s["offset"] + (addr - s["addr"])
+        return None
+
+    # -- typed reads ----------------------------------------------------------
+    def u32(self, addr: int) -> int:
+        o = self.v2o(addr)
+        return 0 if o is None else struct.unpack_from("<I", self.d, o)[0]
+
+    def ptr_target(self, addr: int) -> int | None:
+        """Resolve the pointer stored at *addr* to a virtual address.
+
+        Prefers the relocation (position-independent objects store 0 in the
+        slot and carry the real target as an addend), falling back to a literal
+        qword for the rare non-relocated pointer.
+        """
+        r = self.reloc.get(addr)
+        if r is not None:
+            if r[0] == "rel":
+                return r[1]
+            base = self.syms.get(r[1], {}).get("value")
+            return None if base is None else base + r[2]
+        o = self.v2o(addr)
+        if o is None:
+            return None
+        v = struct.unpack_from("<Q", self.d, o)[0]
+        return v or None
+
+    def cstr(self, addr: int | None, maxlen: int = 4096) -> str:
+        if not addr:
+            return ""
+        o = self.v2o(addr)
+        if o is None:
+            return ""
+        e = self.d.find(b"\x00", o, o + maxlen)
+        if e < 0:
+            e = o + maxlen
+        try:
+            return self.d[o:e].decode("utf-8")
+        except UnicodeDecodeError:
+            return self.d[o:e].decode("latin1")
+
+    def sym(self, name: str) -> dict | None:
+        return self.syms.get(name)
+
+    def sym_at(self, addr: int) -> tuple[str, int] | None:
+        """Return (name, size) of the OBJECT symbol starting at *addr*."""
+        return self._by_addr.get(addr)
+
+
+@dataclass
+class SoCatalog:
+    """Result of :func:`extract_catalog`."""
+    lib: str
+    bus: str
+    messages: dict[str, dict] = field(default_factory=dict)
+    # signals present in the .so but whose enum/units we captured; layout is
+    # never known from the .so alone.
+    signal_count: int = 0
+    value_table_count: int = 0
+
+
+def _value_map(elf: ElfImage, addr: int, size: int) -> dict[str, int]:
+    """Parse a Diag_* value table into {label: raw_value}."""
+    out: dict[str, int] = {}
+    for k in range(size // MAP_STRIDE):
+        base = addr + k * MAP_STRIDE
+        val = elf.u32(base)
+        label = elf.cstr(elf.ptr_target(base + 8))
+        if not label:  # terminator / hole
+            continue
+        out.setdefault(label, val)
+    return out
+
+
+def extract_catalog(path: str | Path, bus: str | None = None) -> SoCatalog:
+    """Extract the full ETH signal catalog from *path* (a libQtCarCANData .so).
+
+    Returns messages keyed by name in (a subset of) the compact.json schema:
+    each message carries ``message_id``, ``length_bytes``, ``cycle_time``,
+    ``originNode``/``senders``/``bus`` and a ``signals`` dict; each signal
+    carries ``units`` and ``value_description`` ({label: value}). Layout fields
+    (start_position/width/scale/offset/...) are intentionally absent -- overlay
+    them from a compact.json donor.
+    """
+    elf = ElfImage(path)
+    if "ETH_messages" not in elf.syms:
+        raise ValueError(f"{path}: no ETH_messages table (not a CANData lib?)")
+
+    # Bus name from CANBusList if present, else default to "ETH".
+    if bus is None:
+        bus = "ETH"
+        cbl = elf.sym("CANBusList")
+        if cbl:
+            nm = elf.cstr(elf.ptr_target(cbl["value"]))
+            if nm:
+                bus = nm
+
+    cat = SoCatalog(lib=Path(path).name, bus=bus)
+    msgsym = elf.syms["ETH_messages"]
+    n_msgs = msgsym["size"] // MSG_STRIDE
+
+    for i in range(n_msgs):
+        b = msgsym["value"] + i * MSG_STRIDE
+        mname = elf.cstr(elf.ptr_target(b + 0x00))
+        if not mname:
+            continue
+        can_id = elf.u32(b + 0x08)
+        dlc = elf.u32(b + 0x0C)
+        cycle = elf.u32(b + 0x10)
+        sig_count = elf.u32(b + 0x14)
+        sig_target = elf.ptr_target(b + 0x20)
+
+        signals: dict[str, dict] = {}
+        if sig_target:
+            info = elf.sym_at(sig_target)
+            avail = (info[1] // SIG_STRIDE) if info else sig_count
+            for j in range(max(sig_count, avail)):
+                sb = sig_target + j * SIG_STRIDE
+                sname = elf.cstr(elf.ptr_target(sb + 0x00))
+                if not sname:
+                    continue
+                units = elf.cstr(elf.ptr_target(sb + 0x10))
+                sig: dict = {}
+                if units:
+                    sig["units"] = units
+                vm_target = elf.ptr_target(sb + 0x20)
+                if vm_target:
+                    vinfo = elf.sym_at(vm_target)
+                    if vinfo:
+                        vd = _value_map(elf, vm_target, vinfo[1])
+                        if vd:
+                            sig["value_description"] = vd
+                            sig["value_table_name"] = vinfo[0].removeprefix(
+                                "Diag_").removesuffix("_map")
+                            cat.value_table_count += 1
+                signals[sname] = sig
+                cat.signal_count += 1
+
+        prefix = mname.split("_", 1)[0]
+        cat.messages[mname] = {
+            "message_id": can_id,
+            "length_bytes": dlc,
+            "cycle_time": cycle,
+            "originNode": prefix,
+            "senders": [prefix],
+            "bus": bus,
+            "signals": signals,
+        }
+    return cat
+
+
+def to_compact_dict(cat: SoCatalog, product: str = "Model3") -> dict:
+    """Render a :class:`SoCatalog` as a compact.json-shaped dict."""
+    return {
+        "product": product,
+        "version": f"from:{cat.lib}",
+        "busMetadata": {cat.bus: {"messageCount": len(cat.messages)}},
+        "messages": cat.messages,
+    }
+
+
+if __name__ == "__main__":  # tiny smoke test / CLI
+    import argparse
+    import json
+
+    ap = argparse.ArgumentParser(description="Dump ETH catalog from a .so")
+    ap.add_argument("lib", type=Path, help="libQtCarCANData.so")
+    ap.add_argument("-o", "--out", type=Path, help="write catalog JSON")
+    a = ap.parse_args()
+    c = extract_catalog(a.lib)
+    print(f"{c.lib}: bus={c.bus} messages={len(c.messages)} "
+          f"signals={c.signal_count} value_tables={c.value_table_count}")
+    if a.out:
+        a.out.write_text(json.dumps(to_compact_dict(c), indent=2))
+        print(f"wrote {a.out}")


### PR DESCRIPTION
Builds a rich Model 3 ETH DBC by combining two firmware sources the user
extracts themselves.

- **`so_candata.py`** — extracts the full signal catalog (message IDs, DLCs,
  cycle times, signal names, units, enum tables) from the infotainment
  `libQtCarCANData.so`.
- **`candata_to_dbc.py`** — marries that catalog (topology + units + enums) with
  the per-revision `compact.json` bit-layout (start/width/scale/offset) into one
  rich DBC — far more messages than `compact.json` carries alone.
- **`compact_to_dbc.py`** — gains an in-memory `convert_db()` entry point (used
  by `candata_to_dbc`), a DBC version string, and `CM_` signal comments.

Pure tooling over a firmware `.so` you supply; no Tesla data is bundled. Full
suite green; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
