### PR TITLE
feat(alerts): alertLog decoder + per-bus alert catalogue dumper

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,3 +15,9 @@ TM3_INTERFACE=socketcan
 # Supply a key you are lawfully entitled to use, for firmware on hardware you own.
 # This project ships no keys and no key-extraction tooling.
 # TM3_BIN_KEY=<base64-encoded value>
+
+# Optional: firmware-derived alertLog field bit-layouts for alert_log.py, so the
+# alert-log decoder resolves every logged field instead of just the leading
+# reason. Point at a rev-tagged alertlog_layouts_<rev>.json; without it the
+# decoder still returns the reason and the CAN-rationality fields.
+# TM3_ALERTLOG_LAYOUTS=/path/to/alertlog_layouts_2022.45.15.json

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,8 @@ docs/superpowers
 *.dbc
 immo_keys.json
 docs/private/
+# Extracted alert catalogue + per-model dumps from dump_alerts.py (real alert data)
+alerts/
 
 # Sensitive local-only layer — never publish (provider seam keeps these out of the tree)
 *.key

--- a/alert_log.py
+++ b/alert_log.py
@@ -1,0 +1,581 @@
+"""Decode Tesla ECU ``<NODE>_alertLog`` CAN messages.
+
+Every Tesla ECU broadcasts a ``<NODE>_alertLog`` frame (DIR 0x5A5, PCS 0x424,
+DI 0x527, VCFRONT 0x534, ...). They share one framework:
+
+    byte0 = alert code (the multiplexer -- which alert this frame logs)
+    bytes 1..7 = that alert's log payload (alert-specific fields)
+
+Alert code N under node X names alert ``X_aNNN`` (see :mod:`so_alerts`), whose
+description says what the payload means. The *CAN-rationality* alerts
+(``canDataBus*`` / ``canRationality``) carry the offending CAN id + an error
+type; the exact packing differs by ECU firmware family (not by silicon -- DU
+and PCS are both TI C28x, they just pack their logs differently):
+
+  * Drive Unit (DU) ECUs -- DIR, DIF, DI, PMR, PMF, PM -- pack both into
+    word1 (little-endian u16 at bytes 2-3): ``canID = word1 & 0x0FFF``,
+    ``errorType = (word1 >> 12) & 7``; word2/word3 = badValue1/2. Confirmed
+    on-vehicle: ``5E 80 A1 33 1C 00 00 00`` -> a094 canID 0x3A1
+    (VCFRONT_vehicleStatus) errorType 3 (CHECKSUM).
+
+  * PCS packs ``errorType = byte2 & 7`` and ``canID = byte3 | byte4<<8``
+    (per Damien Maguire's openinverter ``PCSCan::handle424``).
+
+Beyond the rationality alerts, one field is decodable for ANY alert: the first
+log signal. ``a094`` pins the payload's first field to bit 16 (canID occupies
+bits 16-27), so whatever signal the catalog lists first for an alert starts
+there too. When that signal carries a value table -- 507 alerts do, and they are
+overwhelmingly the ``*Reason`` / ``*Cause`` / ``*AbortReason`` fields that say
+*why* the ECU raised the alert -- its low bits can be read and labelled without
+knowing the field's true width: every value the table defines fits inside the
+mask implied by the table's own maximum. Values outside the table are reported
+raw rather than mislabelled. Example, real bench frame::
+
+    0x527 A2 80 04 00 00 01 22 7C
+      -> DI_a162_shiftDenied, DI_a162_shiftDeniedReason = SYS_STATE_NOT_ENABLED
+
+The remaining log signals need per-alert field widths that no shipped artifact
+carries (the .so catalog has names, units and value tables but no bit layout;
+compact.json and the year DBCs have no alertLog message at all). For most alerts
+they are therefore listed by name with the raw payload words rather than guessed
+at. For drive-unit alerts whose firmware packer was recovered by the layout
+extractor every field decodes, so the a162 frame above also yields
+currentGear = N, requestedGear = D, essContClosed, pedalPos and the rest.
+Those layouts are firmware-derived; point ``TM3_ALERTLOG_LAYOUTS`` at a rev-tagged
+``alertlog_layouts_<rev>.json`` to enable them. A checkout without one decodes the
+reason and nothing further.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+
+# NODE_<type><code>[_suffix] -- the shape shared by alert-matrix signal names in
+# the CAN DB and alert names in the MCU catalog. Same grammar as so_alerts, plus
+# the trailing suffix so it can be prettified into a short human title.
+_ALERT_NAME_RE = re.compile(r"^([A-Z][A-Z0-9]+)_([a-z]{1,2})(\d+)(?:_(.+))?$")
+_CAMEL_SPLIT_RE = re.compile(r"(?<=[a-z0-9])(?=[A-Z])|_")
+# Words that read as acronyms in a title rather than as words. Tesla alert
+# suffixes are dense with them ("hwHvilNotPresent", "canDataBusA").
+_ACRONYMS = frozenset((
+    "can", "hw", "sw", "hv", "lv", "dc", "ac", "hvil", "mia", "crc", "id", "ui",
+    "vdc", "abs", "esp", "epb", "abs", "pcs", "bms", "di", "dir", "dif", "pm",
+    "pmr", "pmf", "uds", "pwm", "adc", "dac", "soc", "ptc", "cmp", "igbt", "isc",
+    "obd", "ess", "hvp", "gtw", "das", "rcm", "sccm", "opd", "ibst",
+))
+
+ERROR_TYPES = {
+    0: "NONE", 1: "LENGTH_SHORT", 2: "LENGTH_LONG", 3: "CHECKSUM",
+    4: "SEQUENCE", 5: "DATA_INVALID", 6: "UNKNOWN_ID",
+}
+
+# ECU firmware family -> how a CAN-rationality alert packs
+# (canID, errorType, bad1, bad2). DU and PCS are both C28x silicon but their
+# alertLog payloads are laid out differently.
+_DU_NODES = ("DIR", "DIF", "DI", "PMR", "PMF", "PM")
+
+
+def _rat_du(d: bytes):
+    """Drive Unit (DIR/DIF/DI/PMR/PMF/PM): word1 packs canID(0-11) | errorType(12-14)."""
+    w1 = d[2] | (d[3] << 8)
+    return (w1 & 0x0FFF, (w1 >> 12) & 0x7, d[4] | (d[5] << 8), d[6] | (d[7] << 8))
+
+
+def _rat_pcs(d: bytes):
+    """PCS (openinverter handle424): errorType=byte2&7, canID=byte3|byte4<<8."""
+    return (d[3] | (d[4] << 8), d[2] & 0x7, None, None)
+
+
+# byte1 bit7: SET on every alertLog frame captured so far (a094 x2, a162), and
+# the catalog declares <NODE>_alertState (CLEARED/SET) right after <NODE>_alertID.
+# The raw header byte is always surfaced alongside so a different pattern is
+# visible rather than silently relabelled.
+ALERT_STATES = {0: "CLEARED", 1: "SET"}
+
+
+_RATIONALITY = dict.fromkeys(_DU_NODES, _rat_du)
+_RATIONALITY["PCS"] = _rat_pcs
+
+
+# alertLog field layouts, keyed (node, code) -> {field: (bit_offset, width,
+# signed)} over the log-payload area (frame bytes 2-7) as a little-endian bit
+# string -- offset 0 is byte2 bit0, the same view _decode_reason takes. The
+# shipped artifacts carry field names/units/value-tables but NO bit positions
+# (see the module docstring), so these are recovered from the drive-unit
+# firmware: each alert's snapshot packer is parsed, and the field count is
+# checked against the catalog's log_signals with a non-overlap/<=48-bit gate.
+# Enum and unit labelling still comes from the per-revision catalog at decode
+# time, so a layout serves every revision that keeps those fields; a field the
+# catalog no longer lists is simply skipped. DI_a162 shiftDenied is the anchor,
+# cross-checked against bench frame A2 80 04 00 00 01 46 7C (shiftDeniedReason
+# SYS_STATE_NOT_ENABLED, currentGear N, requestedGear D).
+#
+# The layouts themselves are firmware-derived and are NOT shipped: point
+# TM3_ALERTLOG_LAYOUTS at a rev-tagged alertlog_layouts_<rev>.json, or drop such
+# files in an alertlog_layouts/ dir beside this module. Each file is tagged with
+# the firmware rev it was extracted from, since alertLog packing shifts between
+# builds.
+_LAYOUTS_DIR = Path(__file__).with_name("alertlog_layouts")
+
+
+def _layouts_path() -> Path:
+    """Locate the rev-tagged layouts file.
+
+    ``TM3_ALERTLOG_LAYOUTS`` wins. Otherwise prefer the rev in ``config.FW_VERSION``
+    (the bench firmware), then fall back to the newest ``alertlog_layouts_*.json``.
+    """
+    env = os.environ.get("TM3_ALERTLOG_LAYOUTS")
+    if env:
+        return Path(env)
+    try:                                          # optional: match the configured rev
+        import config
+        rev = getattr(config, "FW_VERSION", None)
+    except Exception:
+        rev = None
+    if rev:
+        p = _LAYOUTS_DIR / f"alertlog_layouts_{rev}.json"
+        if p.exists():
+            return p
+    tagged = sorted(_LAYOUTS_DIR.glob("alertlog_layouts_*.json"))
+    return tagged[-1] if tagged else _LAYOUTS_DIR / "alertlog_layouts.json"
+
+
+def _load_layouts() -> dict[tuple[str, int], dict[str, tuple[int, int, bool]]]:
+    """Load the extracted layouts, if any are configured.
+
+    Absent -- the normal case unless TM3_ALERTLOG_LAYOUTS or a local
+    alertlog_layouts/ file is provided -- means no layouts, and decode falls back
+    to the leading-enum reason only. Never an error: the layouts are an
+    enrichment, not a dependency.
+    """
+    try:
+        raw = json.loads(_layouts_path().read_text())
+    except (OSError, ValueError):
+        return {}
+    out: dict[tuple[str, int], dict[str, tuple[int, int, bool]]] = {}
+    for node, alerts in raw.get("layouts", {}).items():
+        for code, fields in alerts.items():
+            m = re.search(r"(\d+)", code)
+            if not m:
+                continue
+            out[(node, int(m.group(1)))] = {
+                nm: tuple(spec) for nm, spec in fields.items()}
+    return out
+
+
+_LAYOUTS = _load_layouts()
+
+
+def apply_layout(layout: dict[str, tuple[int, int, bool]], payload: int) -> dict[str, int]:
+    """Extract each field's (signed) integer value from a log-payload int.
+
+    ``payload`` is frame bytes 2-7 as a little-endian integer (bit 0 == byte2
+    bit0). ``layout`` maps a field's suffix name to ``(bit_offset, width,
+    signed)``. Pure bit math -- no catalog needed -- so it pins the reversed
+    layouts in tests independently of the firmware libs.
+    """
+    out: dict[str, int] = {}
+    for name, spec in layout.items():
+        bit, width, signed = spec[0], spec[1], spec[2]
+        raw = (payload >> bit) & ((1 << width) - 1)
+        if signed and raw >= (1 << (width - 1)):
+            raw -= 1 << width
+        out[name] = raw
+    return out
+
+
+def split_alert_name(name: str) -> tuple[str | None, str | None, int | None, str]:
+    """``"DIR_a094_canDataBusA"`` -> ``("DIR", "a", 94, "canDataBusA")``."""
+    m = _ALERT_NAME_RE.match(name or "")
+    if not m:
+        return None, None, None, ""
+    return m.group(1), m.group(2), int(m.group(3)), m.group(4) or ""
+
+
+def pretty_alert_title(name: str) -> str:
+    """Short human title from the alert name's camelCase suffix.
+
+    ``DIR_a050_noStatorSensor`` -> ``"No stator sensor"``. Always available (it
+    needs no catalog), so it's the fallback title when a build's catalog has no
+    record for an alert the CAN DB knows about.
+    """
+    _node, _t, _code, suffix = split_alert_name(name)
+    if not suffix:
+        return name
+    words = [w for w in _CAMEL_SPLIT_RE.split(suffix) if w]
+    if not words:
+        return suffix
+    # Acronyms read as acronyms ("hwHvil" -> "HW HVIL"); ordinary CamelCase words
+    # drop to lower case so the title reads as a sentence.
+    out = [w.upper() if w.lower() in _ACRONYMS else (w if w.isupper() else w[0].lower() + w[1:])
+           for w in words]
+    head = out[0] if out[0].isupper() else out[0][0].upper() + out[0][1:]
+    return " ".join([head, *out[1:]])
+
+
+def alert_view(name: str, rec: dict | None = None) -> dict:
+    """UI-ready view of one alert: short title + whatever catalog text exists.
+
+    ``rec`` is a catalog record from :mod:`so_alerts` (via
+    :meth:`AlertLogDecoder.describe`); ``None`` yields the name-only view, which
+    is what every consumer gets when the MCU libs aren't available.
+    """
+    node, ctype, code, _suffix = split_alert_name(name)
+    view = {
+        "name": name,
+        "node": node,
+        "code": f"{ctype}{code:03d}" if ctype and code is not None else None,
+        "title": pretty_alert_title(name),
+        "catalog_name": None,
+        "description": None,
+        "cause": None,
+        "clear": None,
+        "effect": None,
+        "audience": None,
+        "log_signals": [],
+    }
+    if rec:
+        view.update(
+            catalog_name=rec.get("name"),
+            description=rec.get("description") or None,
+            cause=rec.get("cause") or None,
+            clear=rec.get("clear") or None,
+            effect=rec.get("effect") or None,
+            audience=rec.get("audience") or None,
+            log_signals=list(rec.get("log_signals") or ()),
+        )
+        # A catalog name with a richer suffix than the DB's wins the title.
+        if rec.get("name") and rec["name"] != name:
+            view["title"] = pretty_alert_title(rec["name"])
+    return view
+
+
+@dataclass
+class AlertLogDecode:
+    can_id: int
+    node: str
+    alert_code: int
+    alert: str | None = None          # e.g. "DIR_a094_canDataBusA"
+    description: str | None = None
+    words: tuple = ()                 # the 3 little-endian payload u16 words
+    # Populated for CAN-rationality alerts on known ECU families:
+    rationality: bool = False
+    offending_id: int | None = None   # the CAN id that failed validation
+    offending_name: str | None = None
+    error_type: int | None = None
+    error_name: str | None = None
+    bad_value1: int | None = None
+    bad_value2: int | None = None
+    log_signals: list = field(default_factory=list)
+    # <NODE>_aNNN_<field> -> {"value": int, "label": str|None, "units": str|None}
+    # for alerts whose bit layout has been reversed (see _LAYOUTS). Empty for the
+    # rationality/reason-only paths.
+    decoded: dict = field(default_factory=dict)
+    view: dict = field(default_factory=dict)  # alert_view() of this alert
+    header: int = 0                   # byte1 verbatim (state + unknown bits)
+    state: str | None = None          # "SET" / "CLEARED" from byte1 bit7
+    # The leading log signal, when it's an enum -- the alert's reason/cause.
+    reason_signal: str | None = None
+    reason_value: int | None = None
+    reason_label: str | None = None   # None when the raw value isn't in the table
+
+    def reason_text(self) -> str | None:
+        """``"shiftDeniedReason: SYS_STATE_NOT_ENABLED"``, or None if undecoded.
+
+        A field literally named ``reason``/``cause`` adds nothing as a prefix
+        (``DIR_a090_reason`` -> just ``TOOSLOW``), so it's dropped.
+        """
+        if self.reason_signal is None:
+            return None
+        value = self.reason_label or self.reason_value
+        short = split_alert_name(self.reason_signal)[3] or self.reason_signal
+        if short.lower() in ("reason", "cause"):
+            return str(value)
+        return f"{short}: {value}"
+
+    def _rat_value_for(self, suffix: str):
+        """The rationality value that belongs to a log field, matched by NAME.
+
+        The four rationality fields (offending id, error type, bad1, bad2) appear
+        in different orders across builds and ECU families -- DIR ``a094`` lists
+        ``[canID, errorType, ...]`` but ``a066`` lists ``[badValue1, badValue2,
+        canID, errorType]``, and PCS ``a030`` lists ``[canRxErrorType, canID]``.
+        Pairing by position mislabels all but one order, so match on the suffix.
+        """
+        s = (suffix or "").lower()
+        if "errortype" in s or "rxerror" in s or "errorreason" in s:
+            return self.error_name if self.error_name is not None else self.error_type
+        if s == "canid" or s.endswith("canid") or s == "id":
+            return self.offending_name or self.offending_id
+        if "badvalue1" in s:
+            return self.bad_value1
+        if "badvalue2" in s:
+            return self.bad_value2
+        return None
+
+    def log_values(self) -> list[dict]:
+        """The alert's logged signals paired with whatever we can decode.
+
+        Three tiers: an alert with a reversed bit layout (see ``_LAYOUTS``)
+        resolves every field, labelled from the catalog and carrying its raw
+        value + units; a CAN-rationality alert resolves its fields (matched to the
+        offending id / error type / bad values by NAME, since their order varies);
+        any other alert resolves its leading enum (the reason) and lists the rest
+        by name with ``value: None`` -- the UI can still say *what* the payload
+        words mean without inventing bit positions for them.
+        """
+        out = []
+        for i, sig in enumerate(self.log_signals):
+            short = sig.removeprefix("ETH_")
+            entry: dict = {"name": short, "value": None}
+            dv = self.decoded.get(short)
+            if dv is not None:
+                entry["value"] = dv["label"] if dv["label"] is not None else dv["value"]
+                if dv["label"] is not None:
+                    entry["raw"] = dv["value"]
+                if dv.get("units"):
+                    entry["units"] = dv["units"]
+                if dv.get("inferred"):
+                    entry["inferred"] = True    # value from a packing-convention fill
+            elif self.rationality:
+                rv = self._rat_value_for(split_alert_name(short)[3] or short)
+                if rv is not None:
+                    entry["value"] = rv
+                elif i == 0 and self.reason_signal is not None:
+                    entry["value"] = self.reason_label or self.reason_value
+            elif i == 0 and self.reason_signal is not None:
+                entry["value"] = self.reason_label or self.reason_value
+            out.append(entry)
+        return out
+
+    def to_dict(self) -> dict:
+        """JSON-friendly decode (what can_live serves to the alert panels)."""
+        d = dict(self.view) if self.view else alert_view(
+            self.alert or f"{self.node}_a{self.alert_code:03d}")
+        d.update(
+            can_id=self.can_id,
+            ecu=self.node,
+            alert_code=self.alert_code,
+            summary=self.summary(),
+            words=list(self.words),
+            header=self.header,
+            state=self.state,
+            reason_signal=self.reason_signal,
+            reason_value=self.reason_value,
+            reason_label=self.reason_label,
+            reason_text=self.reason_text(),
+            rationality=self.rationality,
+            offending_id=self.offending_id,
+            offending_name=self.offending_name,
+            error_type=self.error_type,
+            error_name=self.error_name,
+            bad_value1=self.bad_value1,
+            bad_value2=self.bad_value2,
+            log_values=self.log_values(),
+        )
+        return d
+
+    def summary(self) -> str:
+        base = self.alert or f"{self.node}_a{self.alert_code:03d}"
+        if self.rationality and self.offending_id is not None:
+            who = self.offending_name or f"0x{self.offending_id:03X}"
+            bad = (f", bad={self.bad_value1}/{self.bad_value2}"
+                   if self.bad_value1 is not None else "")
+            return f"{base}: {who} ({self.error_name}{bad})"
+        reason = self.reason_text()
+        if reason:
+            return f"{base}: {reason}"
+        w = " ".join(f"{x:04X}" for x in self.words)
+        return f"{base}: [{w}]"
+
+
+class AlertLogDecoder:
+    """Loads the alert + CAN catalogs once and decodes alertLog frames."""
+
+    def __init__(self, lib_dir: str | Path | None = None):
+        self.alertlog_node: dict[int, str] = {}   # can_id -> node
+        # (node, code_type, code) -> rec. Keyed on the type too: DIR_a094 and a
+        # hypothetical DIR_w094 are different alerts that share a number.
+        self.alert_by_nc: dict[tuple[str, str, int], dict] = {}
+        self.alert_by_name: dict[str, dict] = {}   # exact catalog name -> rec
+        self.msg_name: dict[int, str] = {}         # can_id -> message name
+        # <NODE>_aNNN_<field> -> that log signal's catalog entry (units +
+        # value_description). Bit layout is NOT in the catalog; see the module
+        # docstring for what that does and doesn't allow.
+        self.log_signal: dict[str, dict] = {}
+        self._load(lib_dir)
+
+    def _load(self, lib_dir):
+        if lib_dir is None:
+            import config as _cfg
+            if _cfg.ROOT is None:
+                raise RuntimeError("no lib_dir and config.ROOT (TM3_ROOT) unset")
+            lib_dir = Path(_cfg.ROOT) / "usr/tesla/UI/lib"
+        lib_dir = Path(lib_dir)
+        import so_alerts
+        import so_candata
+        cat = so_candata.extract_catalog(lib_dir / "libQtCarCANData.so")
+        for mn, m in cat.messages.items():
+            self.msg_name[m["message_id"]] = mn
+            if mn.endswith("_alertLog"):
+                self.alertlog_node[m["message_id"]] = mn[:-len("_alertLog")]
+                self.log_signal.update(m.get("signals", {}))
+        for name, a in so_alerts.extract_alerts(
+                lib_dir / "libQtCarAlerts.so").alerts.items():
+            rec = dict(a, name=name)
+            self.alert_by_name[name] = rec
+            if a.get("node") is not None and a.get("code") is not None:
+                key = (a["node"], a.get("code_type") or "a", a["code"])
+                self.alert_by_nc.setdefault(key, rec)
+
+    def is_alertlog(self, can_id: int) -> bool:
+        return can_id in self.alertlog_node
+
+    def describe(self, name: str) -> dict | None:
+        """Catalog record for an alert name, or None if this build has none.
+
+        Falls back from the exact name to (node, type, code) so a CAN DB whose
+        suffix drifted from the catalog's -- different firmware revisions name
+        the same alert number slightly differently -- still resolves.
+        """
+        rec = self.alert_by_name.get(name)
+        if rec is not None:
+            return rec
+        node, ctype, code, _suffix = split_alert_name(name)
+        if node is None:
+            return None
+        return self.alert_by_nc.get((node, ctype, code))
+
+    def view(self, name: str) -> dict:
+        """:func:`alert_view` for *name*, enriched from this build's catalog."""
+        return alert_view(name, self.describe(name))
+
+    def _decode_reason(self, out: AlertLogDecode, payload: int) -> None:
+        """Decode the leading log signal when it's an enum -- the alert's *reason*.
+
+        ``payload`` is bytes 2-7 as a little-endian integer, i.e. the log field
+        area with bit 0 at frame bit 16 (where a094's canID starts). The first
+        signal therefore sits at offset 0. Its true width isn't published, but
+        every value its table defines fits within the table maximum's bit width,
+        so masking to that width reads the value correctly; anything outside the
+        table is left unlabelled rather than guessed.
+        """
+        if not out.log_signals:
+            return
+        first = out.log_signals[0].removeprefix("ETH_")
+        meta = self.log_signal.get(first)
+        vd = (meta or {}).get("value_description")
+        if not vd:
+            return
+        width = max(1, max(vd.values()).bit_length())
+        raw = payload & ((1 << width) - 1)
+        out.reason_signal = first
+        out.reason_value = raw
+        for label, val in vd.items():
+            if val == raw:
+                out.reason_label = label
+                break
+
+    def _decode_layout(self, out: AlertLogDecode, payload: int) -> None:
+        """Fully decode an alert whose field bit-layout has been reversed.
+
+        ``payload`` is bytes 2-7 as a little-endian int (bit 0 == byte2 bit0).
+        Fields absent from the layout -- or from this build's catalog -- are left
+        undecoded; enum and unit labels come from the catalog so the decode stays
+        correct per firmware revision.
+        """
+        layout = _LAYOUTS.get((out.node, out.alert_code))
+        if not layout:
+            return
+        values = apply_layout(layout, payload)
+        for sig in out.log_signals:
+            short = sig.removeprefix("ETH_")
+            fname = split_alert_name(short)[3] or short
+            if fname not in values:
+                continue
+            raw = values[fname]
+            meta = self.log_signal.get(short) or {}
+            vd = meta.get("value_description") or {}
+            label = next((lbl for lbl, val in vd.items() if val == raw), None)
+            spec = layout[fname]
+            out.decoded[short] = {
+                "value": raw, "label": label, "units": meta.get("units"),
+                # 4th spec element flags a value inferred from the packing
+                # convention (a zero-init word / missing aggregator bit), not
+                # recovered from a store -- lower confidence.
+                "inferred": bool(len(spec) > 3 and spec[3])}
+
+    def decode(self, can_id: int, data: bytes) -> AlertLogDecode | None:
+        node = self.alertlog_node.get(can_id)
+        if node is None or len(data) < 2:
+            return None
+        d = bytes(data) + b"\x00" * (8 - len(data))
+        code = d[0]
+        words = (d[2] | d[3] << 8, d[4] | d[5] << 8, d[6] | d[7] << 8)
+        out = AlertLogDecode(can_id=can_id, node=node, alert_code=code, words=words)
+        out.header = d[1]
+        out.state = ALERT_STATES.get((d[1] >> 7) & 1)
+        rec = self.alert_by_nc.get((node, "a", code))
+        if rec:
+            out.alert = rec.get("name")
+            out.description = rec.get("description")
+            out.log_signals = rec.get("log_signals", [])
+        out.view = alert_view(out.alert or f"{node}_a{code:03d}", rec)
+        # CAN-rationality alerts carry the offending id + error type.
+        is_rat = bool(rec) and (
+            "canData" in (out.alert or "") or "canRationality" in (out.alert or "")
+            or "_canRationality" in (out.alert or ""))
+        packer = _RATIONALITY.get(node)
+        if is_rat and packer:
+            cid, etype, bv1, bv2 = packer(d)
+            out.rationality = True
+            out.offending_id = cid
+            out.offending_name = self.msg_name.get(cid)
+            out.error_type = etype
+            out.error_name = ERROR_TYPES.get(etype, f"?{etype}")
+            out.bad_value1, out.bad_value2 = bv1, bv2
+        else:
+            # Read the leading enum (the reason) for every alert, then fully
+            # decode the fields for alerts whose bit layout has been reversed.
+            payload = int.from_bytes(d[2:8], "little")
+            self._decode_reason(out, payload)
+            self._decode_layout(out, payload)
+        return out
+
+
+_DEFAULT: AlertLogDecoder | None = None
+
+
+def get_decoder(lib_dir=None) -> AlertLogDecoder:
+    """Process-wide cached decoder (built from config.ROOT libs by default)."""
+    global _DEFAULT
+    if _DEFAULT is None or lib_dir is not None:
+        dec = AlertLogDecoder(lib_dir)
+        if lib_dir is None:
+            _DEFAULT = dec
+        return dec
+    return _DEFAULT
+
+
+if __name__ == "__main__":
+    import argparse
+
+    ap = argparse.ArgumentParser(description="Decode a Tesla alertLog frame")
+    ap.add_argument("can_id", help="hex CAN id, e.g. 5A5")
+    ap.add_argument("data", help="8 hex bytes, e.g. 5E80A1331C000000 or '5E 80 ..'")
+    ap.add_argument("--lib-dir", help="override UI lib dir")
+    a = ap.parse_args()
+    cid = int(a.can_id, 16)
+    raw = bytes.fromhex(a.data.replace(" ", ""))
+    dec = get_decoder(a.lib_dir)
+    res = dec.decode(cid, raw)
+    if res is None:
+        print(f"0x{cid:X} is not a known *_alertLog message")
+    else:
+        print(res.summary())
+        if res.description:
+            print(f"  {res.description}")

--- a/can_decoder.py
+++ b/can_decoder.py
@@ -285,13 +285,51 @@ class CanDatabase:
     def messages_for_node(self, node: str) -> list[dict[str, Any]]:
         return [self.messages[mid] for mid in self._by_node.get(node, [])]
 
+    def _get_alertlog(self):
+        """Lazily build the Tesla alertLog decoder (best-effort, cached)."""
+        dec = getattr(self, "_alertlog", None)
+        if dec is not None or getattr(self, "_alertlog_tried", False):
+            return dec
+        self._alertlog_tried = True
+        self._alertlog = None
+        try:
+            import alert_log
+            self._alertlog = alert_log.get_decoder()
+        except Exception:
+            pass  # no firmware libs / not applicable -> plain decoding only
+        return self._alertlog
+
+    def _decode_alertlog(self, msg_id: int, data: bytes) -> list[dict[str, Any]]:
+        """Synthetic rows for a <NODE>_alertLog frame (empty if not one)."""
+        dec = self._get_alertlog()
+        if dec is None or not dec.is_alertlog(msg_id):
+            return []
+        r = dec.decode(msg_id, bytes(data))
+        if r is None:
+            return []
+        rows = [{"signal": "alertCode", "value": r.alert_code,
+                 "label": r.alert or "", "units": ""}]
+        if r.rationality and r.offending_id is not None:
+            rows.append({"signal": "offendingMessage", "value": r.offending_id,
+                         "label": r.offending_name or f"0x{r.offending_id:03X}",
+                         "units": ""})
+            rows.append({"signal": "errorType", "value": r.error_type,
+                         "label": r.error_name or "", "units": ""})
+            if r.bad_value1 is not None:
+                rows.append({"signal": "badValue1", "value": r.bad_value1,
+                             "label": "", "units": ""})
+                rows.append({"signal": "badValue2", "value": r.bad_value2,
+                             "label": "", "units": ""})
+        return rows
+
     def decode_frame(
         self, msg_id: int, data: bytes
     ) -> list[dict[str, Any]] | None:
         """Decode a raw CAN frame into a list of signal result dicts."""
+        overlay = self._decode_alertlog(msg_id, data)
         msg = self.messages.get(msg_id)
         if msg is None:
-            return None
+            return overlay or None
 
         # Determine muxer value if present
         muxer_value: int | None = None
@@ -305,7 +343,7 @@ class CanDatabase:
                 muxer_value = raw
                 break
 
-        results = []
+        results = list(overlay)
         for sname, sig in msg["signals"].items():
             if sig.get("is_muxer"):
                 continue  # don't surface the mux selector itself

--- a/docs/alerts.md
+++ b/docs/alerts.md
@@ -1,0 +1,53 @@
+# dump_alerts.py — Dump the alert catalogue per firmware revision
+
+Every firmware build ships `opt/odin/data/<model>/bus-alerts-map.json`: a
+per-model map of which alert IDs are reachable on which vehicle bus. The IDs are
+stored as **per-file salted hashes**, not in the clear. `dump_alerts.py` turns a
+firmware build into a readable per-bus, per-node alert listing.
+
+```
+python dump_alerts.py                         # uses TM3_ROOT from .env
+python dump_alerts.py /path/to/2026.8.3.ice.extracted
+python dump_alerts.py <root> --no-scrape      # catalogue only, no image scrape
+```
+
+## Setup (.env)
+
+Firmware root and paths come from `.env` (see `.env.example`), so a bare
+`python dump_alerts.py` works once configured:
+
+- `TM3_ROOT` — squashfs root of a firmware extraction (default firmware root).
+
+The alert IDs in the map are stored as `sha256(alert_str + salt)` and the bus
+buckets as `sha256(bus_name + salt)`, where the per-file salt is read from the
+map itself. Because the alert strings are also present in the clear in the
+firmware (the `alertd` binary and `libQtCarAlerts.so`), the tool reverses the
+hashes by running known strings through the same recipe and matching — no key or
+external recipe is needed.
+
+## How it works
+
+The key idea: **the plaintext alert catalogue is reusable across builds; the
+per-file salts are not.** The tool keeps a growing plaintext catalogue
+(`--catalog`); reversing a build is just running every known alert string
+through `sha256(str + salt)` for that file's salt and matching. Whatever is
+still unresolved is recovered by scraping the firmware image for alert-shaped
+strings (`--scrape`, default on) — the `alertd` binary is the richest source —
+and every newly-confirmed string is folded back into the catalogue, so coverage
+improves each time a new revision is processed.
+
+Severity and service-UI panel info are merged in from
+`service_ui/static/assets/alerts.json` when present (2025+ builds).
+
+## Output
+
+Dumps and the catalogue default to the gitignored `alerts/` dir (override with
+`--out` / `--catalog`):
+
+- `<rev>-<model>-alerts.json` — per bus: totals, per-node counts, and each
+  alert's `id` / `name` / `node` / `severity` / `panels`, plus any unresolved
+  hashes.
+- `alert_catalog.txt` — the accumulated plaintext catalogue.
+
+These are generated from your firmware extraction; the default `alerts/` dir is
+gitignored so they stay out of the repo.

--- a/dump_alerts.py
+++ b/dump_alerts.py
@@ -1,0 +1,333 @@
+#!/usr/bin/env python3
+"""Dump the alert catalogue a firmware build exposes on each vehicle bus.
+
+Every build ships ``opt/odin/data/<model>/bus-alerts-map.json`` -- a per-model
+map of which alert IDs are reachable on which vehicle bus.  The IDs are stored
+as salted hashes, not in the clear: the map hash of an alert is
+``sha256(alert_str + salt)`` and a bus bucket is ``sha256(bus_name + salt)``,
+where the per-file salt is read from the map itself.  Because the alert strings
+are also present in the clear in the firmware (the alertd binary and
+libQtCarAlerts.so), the tool reverses the hashes by running known strings
+through the same recipe and matching.
+
+Given a firmware root (or the ``TM3_ROOT`` in .env), the tool:
+  * loads each ``bus-alerts-map.json`` and resolves its bucket(s) to bus names;
+  * reverses the alert hashes against a plaintext catalogue it maintains
+    (``--catalog``) by running each known alert string through the recipe
+    and matching;
+  * for anything unresolved, scrapes the firmware image for alert-shaped
+    strings (``--scrape``) and folds newly-confirmed strings back into the
+    catalogue, so coverage improves every time a new revision is processed;
+  * merges severity / UI panel info from service_ui/alerts.json (2025+);
+  * writes ``<rev>-<model>-alerts.json`` per model and prints a summary.
+
+Firmware root, output dir and catalogue all default from .env / the repo, so a
+bare ``python dump_alerts.py`` works once .env is configured.
+
+Usage:
+  python dump_alerts.py [firmware_root] [--out DIR] [--catalog FILE]
+                        [--scrape/--no-scrape] [--quiet]
+
+Example:
+  python dump_alerts.py                      # uses TM3_ROOT from .env
+  python dump_alerts.py /path/to/2026.8.3.ice.extracted
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import subprocess
+import sys
+from collections import Counter
+from pathlib import Path
+
+import config  # loads .env; provides ROOT and path defaults
+import so_alerts  # descriptions + logged-signal map from libQtCarAlerts.so
+
+_REPO = Path(__file__).parent
+
+# Full alert string:  NODE_<type><code>_camelCaseName  (type a/w/d/..., 3-4 digit code)
+_ALERT_RE = re.compile(r"[A-Z][A-Z0-9]{1,15}_[a-z][0-9]{3,4}_[A-Za-z0-9_]{1,96}")
+_ID_RE = re.compile(r"^([A-Z][A-Z0-9]{1,15}_[a-z][0-9]{3,4})")
+_NAMECHARS = set(
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_"
+)
+
+# Generated data (the growing catalogue + the per-model JSON dumps) lands here;
+# this dir is gitignored so extracted alert data is never committed by accident.
+_DEFAULT_OUT = _REPO / "alerts"
+_DEFAULT_CATALOG = _DEFAULT_OUT / "alert_catalog.txt"
+
+# Candidate bus names for resolving a bucket hash -> bus label. Tesla's Bus enum
+# only defines ETH for these platforms; the rest are kept so the tool keeps
+# working if bridged CAN buses are added to the map later.
+BUS_NAMES = [
+    "ETH", "eth", "VEHICLE", "vehicle", "PARTY", "party", "CHASSIS", "chassis",
+    "PT", "pt", "BODY", "body", "POWERTRAIN", "powertrain", "CANV", "CAN",
+]
+
+
+def alert_hash(alert_str: str, salt: str) -> str:
+    """Map hash of a full alert string under a map's salt (lowercase hex)."""
+    return hashlib.sha256((alert_str + salt).encode()).hexdigest()
+
+
+def bus_bucket(bus_name: str, salt: str) -> str:
+    """Bucket hash of a bus name under a map's salt (lowercase hex)."""
+    return hashlib.sha256((bus_name + salt).encode()).hexdigest()
+
+
+def find_odin_dir(root: Path) -> Path:
+    """Accept a firmware root or an opt/odin dir; return the opt/odin dir."""
+    if (root / "data").is_dir() and (root / "alertd").exists():
+        return root
+    cand = root / "opt" / "odin"
+    if cand.is_dir():
+        return cand
+    hits = list(root.glob("**/opt/odin"))
+    if hits:
+        return hits[0]
+    sys.exit(f"could not find opt/odin under {root}")
+
+
+def load_catalog(path: Path) -> set:
+    if not path.exists():
+        return set()
+    return {ln.strip() for ln in path.read_text().splitlines() if ln.strip()}
+
+
+def save_catalog(path: Path, catalog: set) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(sorted(catalog)) + "\n")
+
+
+def harvest_alertd(odin: Path) -> set:
+    """Segment the concatenated alert strings inside the alertd Go binary.
+
+    Strings are stored back-to-back with no separators, so a name that ends in
+    an upper-case run merges into the next alert's prefix.  We slice from each
+    id anchor and keep every end position -- the caller validates against a
+    real hash, so over-captured variants are simply discarded.
+    """
+    out = set()
+    binp = odin / "alertd"
+    if not binp.exists():
+        return out
+    blob = binp.read_bytes().decode("latin-1")
+    for m in re.finditer(r"[A-Z][A-Z0-9]{1,15}_[a-z][0-9]{3,4}", blob):
+        ide = m.end()
+        if ide >= len(blob) or blob[ide] != "_":
+            continue
+        e, lim = ide + 1, min(ide + 96, len(blob))
+        while e < lim and blob[e] in _NAMECHARS:
+            e += 1
+            out.add(blob[m.start():e])
+    return out
+
+
+def scrape_image(root: Path) -> set:
+    """grep the whole firmware image for alert-shaped strings (binary-safe)."""
+    try:
+        res = subprocess.run(
+            ["grep", "-rhoaE", _ALERT_RE.pattern, str(root)],
+            capture_output=True, text=True, timeout=1200, check=False,
+        )
+    except FileNotFoundError:
+        sys.exit("grep not available; run under a POSIX shell")
+    return {ln for ln in res.stdout.splitlines() if ln}
+
+
+def reverse_map(inner: set, salt: str, candidates: set) -> dict:
+    """Return {alert-hash: alert_str} for every inner hash we can explain.
+
+    For each candidate, try every end-trim so concatenated/over-captured raw
+    strings still yield their embedded real alert string.
+    """
+    matched = {}
+    for c in candidates:
+        m = _ID_RE.match(c)
+        if not m:
+            continue
+        ide = m.end()
+        # exact form first (fast path for clean catalogue entries)
+        h = alert_hash(c, salt)
+        if h in inner:
+            matched.setdefault(h, c)
+        # end-trim variants (only needed for raw scraped/binary candidates)
+        for e in range(ide + 2, len(c) + 1):
+            if c[e - 1] not in _NAMECHARS:
+                break
+            h = alert_hash(c[:e], salt)
+            if h in inner and h not in matched:
+                matched[h] = c[:e]
+    return matched
+
+
+def load_ui_alerts(odin: Path) -> dict:
+    """service_ui alerts.json: id-only -> {panels, severity}. Present 2025+."""
+    for p in (
+        odin / "service_ui/static/assets/alerts.json",
+        odin / "service-ui/static/assets/alerts.json",
+    ):
+        if p.exists():
+            try:
+                return json.loads(p.read_text())
+            except Exception:
+                pass
+    return {}
+
+
+def load_so_alert_descs(img_root: Path) -> dict:
+    """name -> record from libQtCarAlerts.so (description, cause/clear/effect,
+    audience, log_signals). Returns {} when the lib isn't in this build."""
+    for rel in ("usr/tesla/UI/lib/libQtCarAlerts.so",
+                "usr/tesla/UI/lib/libQtCarAlerts.so.1.0.0"):
+        p = img_root / rel
+        if p.exists():
+            try:
+                return so_alerts.extract_alerts(p).alerts
+            except Exception as exc:  # noqa: BLE001 - best-effort enrichment
+                print(f"    (libQtCarAlerts parse failed: {exc})", file=sys.stderr)
+                return {}
+    return {}
+
+
+def dump_one(map_path: Path, odin: Path, root: Path, catalog: set,
+             ui: dict, do_scrape: bool, quiet: bool, descs: dict | None = None) -> dict:
+    data = json.loads(map_path.read_text())
+    salt = data["s"]
+    buckets = data["c"]
+    model = map_path.parent.name
+
+    # resolve bucket hashes -> bus names
+    known = {bus_bucket(b, salt): b for b in BUS_NAMES}
+    bus_of = {bh: known.get(bh, f"?{bh[:8]}") for bh in buckets}
+
+    inner_all = set()
+    for v in buckets.values():
+        inner_all.update(v)
+
+    matched = reverse_map(inner_all, salt, catalog)
+    if len(matched) < len(inner_all):
+        matched.update(reverse_map(inner_all, salt, harvest_alertd(odin)))
+    if do_scrape and len(matched) < len(inner_all):
+        if not quiet:
+            print(f"    scraping image for {len(inner_all) - len(matched)} "
+                  f"unresolved (this takes a few minutes)...", file=sys.stderr)
+        found = reverse_map(inner_all, salt, scrape_image(root))
+        for h, s in found.items():
+            matched.setdefault(h, s)
+    # fold clean confirmed strings back into the catalogue
+    catalog.update(matched.values())
+
+    # build per-bus alert records
+    result = {"model": model, "salt": salt, "buses": {}}
+    for bh, hashes in buckets.items():
+        bus = bus_of[bh]
+        alerts = []
+        unresolved = []
+        for h in hashes:
+            full = matched.get(h)
+            if not full:
+                unresolved.append(h)
+                continue
+            mid = _ID_RE.match(full)
+            aid = mid.group(1)
+            name = full[len(aid) + 1:]
+            rec = {"id": aid, "name": name, "node": aid.split("_")[0]}
+            if descs and full in descs:
+                d = descs[full]
+                for k in ("description", "cause", "clear", "effect", "audience"):
+                    if d.get(k):
+                        rec[k] = d[k]
+                if d.get("log_signals"):
+                    rec["log_signals"] = d["log_signals"]
+            if aid in ui:
+                meta = ui[aid]
+                sev = sorted({p.get("severityLevel")
+                              for p in meta.get("panels", {}).values()
+                              if p.get("severityLevel") is not None})
+                if sev:
+                    rec["severity"] = sev
+                rec["panels"] = sorted(meta.get("panels", {}))
+            alerts.append(rec)
+        alerts.sort(key=lambda r: r["id"])
+        result["buses"][bus] = {
+            "total": len(hashes),
+            "resolved": len(alerts),
+            "unresolved": len(unresolved),
+            "nodes": dict(Counter(a["node"] for a in alerts).most_common()),
+            "alerts": alerts,
+            "unresolved_hashes": unresolved,
+        }
+    return result
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    ap.add_argument("firmware_root", type=Path, nargs="?", default=None,
+                    help="squashfs extraction root or opt/odin dir "
+                         "(default: TM3_ROOT from .env)")
+    ap.add_argument("--out", type=Path, default=_DEFAULT_OUT,
+                    help=f"output dir for JSON dumps (default {_DEFAULT_OUT})")
+    ap.add_argument("--catalog", type=Path, default=_DEFAULT_CATALOG,
+                    help="plaintext alert catalogue, grows over time "
+                         f"(default {_DEFAULT_CATALOG})")
+    ap.add_argument("--scrape", dest="scrape", action="store_true", default=True,
+                    help="scrape the image for unresolved alerts (default on)")
+    ap.add_argument("--no-scrape", dest="scrape", action="store_false")
+    ap.add_argument("--quiet", action="store_true")
+    args = ap.parse_args()
+
+    root = args.firmware_root or config.ROOT
+    if root is None:
+        sys.exit("no firmware root: pass one, or set TM3_ROOT in .env")
+    root = Path(root)
+    odin = find_odin_dir(root)
+    # the image root is the tree we scrape; if given opt/odin, climb to it
+    img_root = root
+    if odin == root:
+        img_root = root.parents[1] if len(root.parents) >= 2 else root
+
+    catalog = load_catalog(args.catalog)
+    ui = load_ui_alerts(odin)
+    so_descs = load_so_alert_descs(img_root)
+    if so_descs and not args.quiet:
+        print(f"    libQtCarAlerts.so: {len(so_descs)} alert descriptions",
+              file=sys.stderr)
+    maps = sorted(odin.glob("data/*/bus-alerts-map.json"))
+    if not maps:
+        sys.exit(f"no bus-alerts-map.json under {odin}/data")
+
+    rev = next((p for p in (root, *root.parents) if ".ice" in p.name
+                or ".model3" in p.name), root).name
+
+    args.out.mkdir(parents=True, exist_ok=True)
+    summary = []
+    for mp in maps:
+        res = dump_one(mp, odin, img_root, catalog, ui,
+                       args.scrape, args.quiet, so_descs)
+        outp = args.out / f"{rev}-{res['model']}-alerts.json"
+        outp.write_text(json.dumps(res, indent=2))
+        for bus, b in res["buses"].items():
+            summary.append((rev, res["model"], bus, b["total"],
+                            b["resolved"], b["unresolved"], outp))
+
+    save_catalog(args.catalog, catalog)
+
+    print(f"\ncatalogue: {len(catalog)} alert strings  ({args.catalog})")
+    print(f"{'revision':30} {'model':7} {'bus':6} {'total':>6} "
+          f"{'resolved':>9} {'miss':>5}")
+    for rev, model, bus, tot, res_, miss, _outp in summary:
+        pct = 100 * res_ / tot if tot else 0
+        print(f"{rev:30} {model:7} {bus:6} {tot:6} {res_:9} ({pct:4.0f}%) {miss:5}")
+    print(f"\ndumps written to {args.out}/")
+
+
+if __name__ == "__main__":
+    main()

--- a/so_alerts.py
+++ b/so_alerts.py
@@ -1,0 +1,172 @@
+"""Extract Tesla's alert catalog from the MCU UI ``libQtCarAlerts.so``.
+
+The infotainment alert library embeds, as exported relocated data, the full
+per-build alert catalog -- names, human-readable descriptions and the CAN
+signals each alert logs. This is richer than ``bus-alerts-map.json`` (which
+stores only salted hashes; see :mod:`dump_alerts`): here the names and
+descriptions are in the clear.
+
+Tables (2022.45.15, x86-64 LE; reversed + validated):
+
+    globalBasicAlertDataTable   88-byte records, 6308 alerts
+      +0x00 char*  name              e.g. "BMS_a089_SW_VcFront_MIA"
+      +0x08 u64    hash (name digest)
+      +0x10 u32    index             (matrix/enum index)
+      +0x18 char*  description        human-readable text
+      +0x20 u64    flags
+      +0x28 char*  note              (usually "")
+      +0x30 char*  audience          e.g. "6.0.89"
+      +0x38 char*  cause             set/trigger condition
+      +0x40 char*  clear             clear condition
+      +0x48 char*  effect            consequence / impact
+      +0x50 u64
+
+    globalAlertLogSignalData    24-byte records, 3027 entries
+      +0x00 char*  node              e.g. "BMS"
+      +0x08 u32    code              alert number (the NNN in aNNN)
+      +0x10 char*  comma-joined ETH signal names logged for that alert
+
+    Empty string fields all point at a single shared "" datum.
+
+The two tables join on (node, code) -- code parsed from the alert name -- to
+attach ``log_signals`` to each alert (3027/3027 join in 2022.45.15).
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from so_candata import ElfImage
+
+BASIC_STRIDE = 88
+LOG_STRIDE = 24
+
+# NODE_<type><code>_rest ; type is 1-2 lowercase letters (a, w, sw, sc, e, ...)
+_NAME_RE = re.compile(r"^([A-Z][A-Z0-9]+)_([a-z]{1,2})(\d+)")
+
+
+def _parse_name(name: str) -> tuple[str | None, str | None, int | None]:
+    m = _NAME_RE.match(name)
+    if not m:
+        return None, None, None
+    return m.group(1), m.group(2), int(m.group(3))
+
+
+@dataclass
+class AlertCatalog:
+    lib: str
+    alerts: dict[str, dict] = field(default_factory=dict)
+    log_records: int = 0
+    joined: int = 0
+
+
+def _read_log_map(elf: ElfImage) -> dict[tuple[str, int], list[str]]:
+    """Return {(node, code): [ETH signal names]} from globalAlertLogSignalData."""
+    sym = elf.sym("globalAlertLogSignalData")
+    if not sym:
+        return {}
+    out: dict[tuple[str, int], list[str]] = {}
+    for i in range(sym["size"] // LOG_STRIDE):
+        b = sym["value"] + i * LOG_STRIDE
+        node = elf.cstr(elf.ptr_target(b + 0))
+        code = elf.u32(b + 8)
+        sigs = elf.cstr(elf.ptr_target(b + 16))
+        if node:
+            out[(node, code)] = [s for s in sigs.split(",") if s] if sigs else []
+    return out
+
+
+def extract_alerts(path: str | Path) -> AlertCatalog:
+    """Extract the alert catalog from *path* (a libQtCarAlerts .so)."""
+    elf = ElfImage(path)
+    basic = elf.sym("globalBasicAlertDataTable")
+    if not basic:
+        raise ValueError(f"{path}: no globalBasicAlertDataTable (not an Alerts lib?)")
+    log_map = _read_log_map(elf)
+
+    cat = AlertCatalog(lib=Path(path).name)
+    cat.log_records = len(log_map)
+    for i in range(basic["size"] // BASIC_STRIDE):
+        b = basic["value"] + i * BASIC_STRIDE
+        name = elf.cstr(elf.ptr_target(b + 0))
+        if not name:
+            continue
+        node, ctype, code = _parse_name(name)
+        rec: dict = {
+            "node": node,
+            "code": code,
+            "code_type": ctype,
+            "index": elf.u32(b + 0x10),
+            "description": elf.cstr(elf.ptr_target(b + 0x18)),
+            "cause": elf.cstr(elf.ptr_target(b + 0x38)),
+            "clear": elf.cstr(elf.ptr_target(b + 0x40)),
+            "effect": elf.cstr(elf.ptr_target(b + 0x48)),
+            "audience": elf.cstr(elf.ptr_target(b + 0x30)),
+            "flags": elf.u32(b + 0x20) | (elf.u32(b + 0x24) << 32),
+            "hash": f"0x{(elf.u32(b + 8) | (elf.u32(b + 12) << 32)):016x}",
+        }
+        note = elf.cstr(elf.ptr_target(b + 0x28))
+        if note:
+            rec["note"] = note
+        sigs = log_map.get((node, code)) if node is not None else None
+        if sigs:
+            rec["log_signals"] = sigs
+            cat.joined += 1
+        cat.alerts[name] = rec
+    return cat
+
+
+def to_dict(cat: AlertCatalog, product: str = "Model3", rev: str = "") -> dict:
+    with_desc = sum(1 for a in cat.alerts.values() if a["description"])
+    return {
+        "product": product,
+        "rev": rev,
+        "lib": cat.lib,
+        "count": len(cat.alerts),
+        "with_description": with_desc,
+        "with_log_signals": cat.joined,
+        "alerts": cat.alerts,
+    }
+
+
+if __name__ == "__main__":
+    import argparse
+    import json
+    import sys
+
+    ap = argparse.ArgumentParser(description="Dump the MCU alert catalog")
+    ap.add_argument("lib", type=Path, nargs="?",
+                    help="libQtCarAlerts.so (default: from config.ROOT)")
+    ap.add_argument("--root", help="firmware extraction root (default: TM3_ROOT)")
+    ap.add_argument("--rev", help="firmware rev label (default: from root name)")
+    ap.add_argument("--product", default="Model3")
+    ap.add_argument("-o", "--out", type=Path, help="output JSON path")
+    ap.add_argument("--names-out", type=Path,
+                    help="also write the sorted plaintext alert names (feeds "
+                         "dump_alerts.py's --catalog)")
+    a = ap.parse_args()
+
+    # Resolve lib/rev from config.ROOT the same way candata_to_dbc does.
+    import config as _cfg
+    from candata_to_dbc import _rev_from_lib
+    root = Path(a.root).expanduser() if a.root else _cfg.ROOT
+    lib = a.lib
+    if lib is None:
+        if root is None:
+            sys.exit("no lib given and config.ROOT (TM3_ROOT) is unset")
+        lib = root / "usr/tesla/UI/lib/libQtCarAlerts.so"
+    rev = a.rev or _cfg.FW_VERSION or _rev_from_lib(Path(lib), root)
+
+    cat = extract_alerts(lib)
+    doc = to_dict(cat, product=a.product, rev=rev)
+    print(f"{cat.lib}: rev={rev} alerts={doc['count']} "
+          f"with_description={doc['with_description']} "
+          f"with_log_signals={doc['with_log_signals']}", file=sys.stderr)
+    out = a.out or Path(f"{rev}-{a.product}-so-alerts.json")
+    out.write_text(json.dumps(doc, indent=2, sort_keys=True))
+    print(f"wrote {out}")
+    if a.names_out:
+        a.names_out.write_text("\n".join(sorted(cat.alerts)) + "\n")
+        print(f"wrote {a.names_out} ({len(cat.alerts)} names)")

--- a/tests/test_alert_log.py
+++ b/tests/test_alert_log.py
@@ -1,0 +1,247 @@
+"""Tests for alert_log field packing (firmware-independent).
+
+The catalog-backed name lookups need the UI .so files, so those are exercised
+by the integration tests; here we pin the wire bit-packing that was reversed
+from the DIR firmware and Damien Maguire's openinverter PCS decoder, using the
+real on-vehicle frames captured for a094.
+"""
+
+import pytest
+
+from alert_log import (
+    _LAYOUTS,
+    ERROR_TYPES,
+    AlertLogDecode,
+    _rat_du,
+    _rat_pcs,
+    alert_view,
+    apply_layout,
+    pretty_alert_title,
+    split_alert_name,
+)
+
+# The firmware-derived alertLog bit-layouts are not shipped; tests that need them
+# run only when TM3_ALERTLOG_LAYOUTS (or a local alertlog_layouts/ file) supplies
+# them. Absent -- the normal public case -- they skip.
+needs_layouts = pytest.mark.skipif(
+    not _LAYOUTS, reason="alertlog layouts not configured (TM3_ALERTLOG_LAYOUTS)"
+)
+
+
+def test_du_a094_checksum_frame():
+    # can1 5A5 [8] 5E 80 A1 33 1C 00 00 00  (DIR a094)
+    d = bytes([0x5E, 0x80, 0xA1, 0x33, 0x1C, 0x00, 0x00, 0x00])
+    canid, etype, bv1, bv2 = _rat_du(d)
+    assert canid == 0x3A1            # VCFRONT_vehicleStatus
+    assert etype == 3                # CHECKSUM
+    assert ERROR_TYPES[etype] == "CHECKSUM"
+    assert (bv1, bv2) == (28, 0)
+
+
+def test_du_a094_length_short_frame():
+    # can1 5A5 [8] 5E 80 84 12 05 00 08 00  (DIR a094)
+    d = bytes([0x5E, 0x80, 0x84, 0x12, 0x05, 0x00, 0x08, 0x00])
+    canid, etype, bv1, bv2 = _rat_du(d)
+    assert canid == 0x284            # UI_vehicleModes
+    assert etype == 1                # LENGTH_SHORT
+    assert (bv1, bv2) == (5, 8)
+
+
+def test_pcs_layout_damien():
+    # PCS handle424: errorType = byte2 & 7, canID = byte3 | byte4<<8
+    d = bytes([0x1E, 0x00, 0x03, 0x21, 0x03, 0x00, 0x00, 0x00])
+    canid, etype, bv1, bv2 = _rat_pcs(d)
+    assert canid == 0x321
+    assert etype == 3
+    assert bv1 is None and bv2 is None
+
+
+def test_error_type_table():
+    assert ERROR_TYPES[0] == "NONE"
+    assert ERROR_TYPES[4] == "SEQUENCE"
+    assert ERROR_TYPES[6] == "UNKNOWN_ID"
+
+
+# --- reversed field layouts (firmware-independent bit math) --------------------
+
+
+@needs_layouts
+def test_a162_shift_denied_layout():
+    """Pin the DI_a162 packing reversed from the DIR firmware against the bench
+    frame 0x527 A2 80 04 00 00 01 46 7C (a refused N->D shift)."""
+    payload = int.from_bytes(bytes([0x04, 0x00, 0x00, 0x01, 0x46, 0x7C]), "little")
+    v = apply_layout(_LAYOUTS[("DI", 162)], payload)
+    assert v == {
+        "shiftDeniedReason": 4,        # SYS_STATE_NOT_ENABLED
+        "motorSpeed": 0,
+        "essContClosed": 1,
+        "pedalPos": 0,
+        "currentGear": 3,              # DI_GEAR_N
+        "requestedGear": 4,            # DI_GEAR_D
+        "timeSinceCruiseCancel": 120,
+        "chargeCableConnected": 1,
+        "frunkOpen": 0,
+    }
+
+
+@needs_layouts
+def test_apply_layout_sign_extends():
+    """A signed field reads negative once its top bit is set (motorSpeed, 16b)."""
+    # motorSpeed occupies bits 8-23; set it to -1 (all ones) and nothing else.
+    payload = (0xFFFF << 8)
+    v = apply_layout(_LAYOUTS[("DI", 162)], payload)
+    assert v["motorSpeed"] == -1
+    assert v["shiftDeniedReason"] == 0
+
+
+@needs_layouts
+def test_pcs_layouts_anchor():
+    """PCS alertLog layouts loaded and anchored: a030 canRationality matches Damien's
+    handle424 (errorType=byte2&7, canID=byte3|byte4<<8), a034 hvBusOv decodes, a029 has 4."""
+    assert ("PCS", 30) in _LAYOUTS                   # a030 anchor
+    a030 = _LAYOUTS[("PCS", 30)]
+    assert tuple(a030["canRxErrorType"][:2]) == (0, 3)
+    assert tuple(a030["canID"][:2]) == (8, 16)
+    # a034 hvBusOv: single 12-bit HV_busV at bit 0
+    a034 = _LAYOUTS[("PCS", 34)]
+    assert tuple(next(iter(a034.values()))[:2]) == (0, 12)
+    assert apply_layout(a034, 0x123)["HV_busV"] == 291
+    # a029 chgPowerRationality: 4 fields
+    assert len(_LAYOUTS[("PCS", 29)]) == 4
+
+
+@needs_layouts
+def test_layouts_artifact_loaded_and_sane():
+    """The bundled alertlog_layouts_<rev>.json loads, and every layout is in-bounds and
+    non-overlapping (the extractor's gate must hold for what shipped)."""
+    assert len(_LAYOUTS) >= 20                       # the extracted set
+    assert ("DI", 162) in _LAYOUTS                   # anchor alert present
+    for (node, code), fields in _LAYOUTS.items():
+        assert node in ("DI", "DIR", "PCS")
+        # specs are [bit, width, signed] or [bit, width, signed, inferred]
+        spans = sorted((s[0], s[0] + s[1]) for s in fields.values())
+        assert spans[-1][1] <= 48, f"{node}_a{code} exceeds 48 bits"
+        for i in range(1, len(spans)):
+            assert spans[i][0] >= spans[i - 1][1], f"{node}_a{code} overlaps"
+        for _nm, spec in fields.items():
+            _b, w, signed = spec[0], spec[1], spec[2]
+            if signed:                               # narrow fields never signed
+                assert w >= 6
+            if len(spec) > 3:                        # 4th element is the inferred flag
+                assert isinstance(spec[3], bool)
+
+
+@needs_layouts
+def test_inferred_fill_marked_and_anchored():
+    """The consecutive-packing fill supplies missing fields flagged inferred,
+    while recovered fields carry no such flag."""
+    # a162's fully-recovered fields are never flagged inferred
+    for spec in _LAYOUTS[("DI", 162)].values():
+        assert len(spec) == 3 or spec[3] is False
+    # a133 badValue1 is a zero-init middle word -> inferred full word at bit 16
+    a133 = _LAYOUTS.get(("DIR", 133))
+    if a133:                                          # present only when layouts are configured
+        bv1 = a133["badValue1"]                       # keys are field suffixes
+        assert tuple(bv1[:2]) == (16, 16) and len(bv1) > 3 and bool(bv1[3])
+        assert len(a133["capacitorTemp"]) == 3        # recovered, unflagged
+
+
+def test_log_values_uses_decoded_layout():
+    """When a frame carried a reversed layout, every field resolves (labelled)."""
+    d = AlertLogDecode(
+        can_id=0x527, node="DI", alert_code=162,
+        log_signals=["ETH_DI_a162_shiftDeniedReason", "ETH_DI_a162_currentGear",
+                     "ETH_DI_a162_motorSpeed"],
+        decoded={
+            "DI_a162_shiftDeniedReason": {
+                "value": 4, "label": "SYS_STATE_NOT_ENABLED", "units": None},
+            "DI_a162_currentGear": {"value": 3, "label": "N", "units": None},
+            "DI_a162_motorSpeed": {"value": 0, "label": None, "units": "MPH"},
+        })
+    vals = {v["name"]: v for v in d.log_values()}
+    assert vals["DI_a162_shiftDeniedReason"]["value"] == "SYS_STATE_NOT_ENABLED"
+    assert vals["DI_a162_shiftDeniedReason"]["raw"] == 4
+    assert vals["DI_a162_currentGear"]["value"] == "N"
+    assert vals["DI_a162_motorSpeed"]["value"] == 0
+    assert vals["DI_a162_motorSpeed"]["units"] == "MPH"
+
+
+# --- name parsing / human titles (no firmware libs needed) --------------------
+
+
+@pytest.mark.parametrize(("name", "parts"), [
+    ("DIR_a094_canDataBusA", ("DIR", "a", 94, "canDataBusA")),
+    ("BMS_a089_SW_VcFront_MIA", ("BMS", "a", 89, "SW_VcFront_MIA")),
+    ("APP_sw191_abortReason", ("APP", "sw", 191, "abortReason")),
+    ("DI_a126_limpMode", ("DI", "a", 126, "limpMode")),
+    ("not_an_alert", (None, None, None, "")),
+])
+def test_split_alert_name(name, parts):
+    assert split_alert_name(name) == parts
+
+
+@pytest.mark.parametrize(("name", "title"), [
+    ("DIR_a050_noStatorSensor", "No stator sensor"),
+    ("DIR_a007_hwHvilNotPresent", "HW HVIL not present"),
+    ("DIR_a094_canDataBusA", "CAN data bus A"),
+    ("DI_a162_shiftDenied", "Shift denied"),
+])
+def test_pretty_alert_title(name, title):
+    assert pretty_alert_title(name) == title
+
+
+def test_alert_view_without_catalog():
+    """No catalog record -> name-derived title, no invented prose."""
+    v = alert_view("DIR_a050_noStatorSensor")
+    assert v["node"] == "DIR" and v["code"] == "a050"
+    assert v["title"] == "No stator sensor"
+    assert v["description"] is None and v["cause"] is None
+    assert v["log_signals"] == []
+
+
+def test_alert_view_prefers_catalog_suffix():
+    """A CAN DB name that drifted from the catalog's still titles from the catalog."""
+    rec = {"name": "DIR_a050_noStatorSensor", "description": "no stator sensor available"}
+    v = alert_view("DIR_a050_noStatorSensorTemp", rec)
+    assert v["name"] == "DIR_a050_noStatorSensorTemp"       # what the bus called it
+    assert v["catalog_name"] == "DIR_a050_noStatorSensor"
+    assert v["title"] == "No stator sensor"
+
+
+# --- log payload rendering ----------------------------------------------------
+
+
+def test_log_values_fills_rationality_then_names():
+    d = AlertLogDecode(
+        can_id=0x5A5, node="DIR", alert_code=94, rationality=True,
+        offending_name="VCFRONT_vehicleStatus", error_name="CHECKSUM",
+        bad_value1=28, bad_value2=0,
+        log_signals=["ETH_DIR_a094_canID", "ETH_DIR_a094_errorType",
+                     "ETH_DIR_a094_badValue1", "ETH_DIR_a094_badValue2"])
+    vals = d.log_values()
+    assert [v["name"] for v in vals] == [
+        "DIR_a094_canID", "DIR_a094_errorType", "DIR_a094_badValue1", "DIR_a094_badValue2"]
+    assert [v["value"] for v in vals] == ["VCFRONT_vehicleStatus", "CHECKSUM", 28, 0]
+
+
+def test_log_values_leaves_unreversed_fields_undecoded():
+    """Only the leading reason resolves; the rest must stay None, not be guessed."""
+    d = AlertLogDecode(
+        can_id=0x527, node="DI", alert_code=162,
+        reason_signal="DI_a162_shiftDeniedReason", reason_value=4,
+        reason_label="SYS_STATE_NOT_ENABLED",
+        log_signals=["ETH_DI_a162_shiftDeniedReason", "ETH_DI_a162_motorSpeed",
+                     "ETH_DI_a162_currentGear"])
+    vals = d.log_values()
+    assert vals[0]["value"] == "SYS_STATE_NOT_ENABLED"
+    assert vals[1]["value"] is None and vals[2]["value"] is None
+    assert d.reason_text() == "shiftDeniedReason: SYS_STATE_NOT_ENABLED"
+
+
+def test_summary_prefers_reason_over_raw_words():
+    d = AlertLogDecode(can_id=0x527, node="DI", alert_code=162,
+                       alert="DI_a162_shiftDenied", words=(4, 0x100, 0x7C22))
+    assert d.summary() == "DI_a162_shiftDenied: [0004 0100 7C22]"
+    d.reason_signal, d.reason_value = "DI_a162_shiftDeniedReason", 4
+    d.reason_label = "SYS_STATE_NOT_ENABLED"
+    assert d.summary() == "DI_a162_shiftDenied: shiftDeniedReason: SYS_STATE_NOT_ENABLED"


### PR DESCRIPTION
Decodes Tesla ECU alert logs and reverses the per-build alert map.

- **`alert_log.py`** — decodes `<NODE>_alertLog` CAN frames (byte0 mux +
  per-alert log payload): CAN-rationality (offending id + error type) for the DU
  and PCS families, the leading `*Reason` enum for any alert, and full field
  decode when firmware-derived bit-layouts are supplied via
  `TM3_ALERTLOG_LAYOUTS` (none shipped; degrades to reason-only).
- **`dump_alerts.py`** — reverses a build's `bus-alerts-map.json` (salted
  `sha256` hashes) into a readable per-bus / per-node listing. The recipe is
  `sha256(str + salt)` with the salt read from the map; the alert strings come
  from the firmware's own `alertd` binary + `libQtCarAlerts.so`, so no key or
  external provider is needed.
- **`so_alerts.py`** — extracts the alert catalog (names, descriptions, logged
  signals) from `libQtCarAlerts.so`.
- **`can_decoder.py`** — overlays decoded alertLog rows onto `decode_frame`
  (best-effort; a no-op without `alert_log`'s inputs).

Generated dumps/catalogue default to a gitignored `alerts/` dir. Full suite
green (2489 passed, 12 skipped); ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
