### PR TITLE
feat(can_live): dashboard overhaul + firmware-optional decoding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,8 @@ seed_artifacts_v2/
 .vscode/
 docs/superpowers
 *.dbc
+# keep small synthetic DBC test fixtures
+!tests/fixtures/*.dbc
 immo_keys.json
 docs/private/
 # Extracted alert catalogue + per-model dumps from dump_alerts.py (real alert data)

--- a/can_decoder.py
+++ b/can_decoder.py
@@ -163,15 +163,21 @@ def decode_signal(data: bytes, sig: dict[str, Any], name: str = "") -> tuple[flo
 class CanDatabase:
     """Parsed representation of a compact JSON or DBC CAN database."""
 
-    def __init__(self, path: Path = _ETH_COMPACT) -> None:
+    def __init__(self, path: Path | None = _ETH_COMPACT) -> None:
+        self.messages: dict[int, dict[str, Any]] = {}  # msg_id -> msg
+        self._by_node: dict[str, list[int]] = {}
+        self._cantools_db = None
+
+        # No compact JSON configured (no firmware root / TM3_ROOT) -> an empty DB.
+        # Callers still work: can_live shows raw undecoded frames, and a DBC can be
+        # supplied instead via CanDatabase.from_dbc(). Decoding just names nothing.
+        if path is None:
+            return
+
         # Use the same loader as uds_local/node_config.py so an encrypted .bin
         # twin (Model3_ETH.compact.json.bin) is auto-decrypted instead of being
         # fed raw to json.load (which fails with a UnicodeDecodeError).
         raw = _load_json(Path(path))
-
-        self.messages: dict[int, dict[str, Any]] = {}  # msg_id -> msg
-        self._by_node: dict[str, list[int]] = {}
-        self._cantools_db = None
 
         for name, msg in raw["messages"].items():
             mid = msg["message_id"]

--- a/can_live.py
+++ b/can_live.py
@@ -1,10 +1,38 @@
 #!/usr/bin/env python3
 """Live CAN viewer — aiohttp backend with WebSocket streaming.
 
+Pipeline (sized for a full vehicle bus, not just a quiet bench):
+
+    bus.recv() in a dedicated OS thread per bus
+        -> per-ID coalescing buffer (latest frame wins, arrivals counted)
+        -> asyncio flusher at --ui-rate Hz
+        -> ONE batched JSON message per tick
+        -> per-client writer task with a latest-wins outbox
+
+Three rules keep it from saturating:
+  * The CAN reader never touches asyncio, JSON, or a socket — it only buffers,
+    so nothing on the browser side can stall bus ingest and overflow the RX queue.
+  * Within a flush tick only the newest frame per (bus, ID) survives; the frames
+    coalesced away are still counted, so the displayed rate stays truthful even
+    though a 100 Hz message only paints 20 times a second.
+  * A slow client drops stale batches instead of applying backpressure.
+
+The read-only viewer lives at ``/``. A separate driver-HUD dashboard (speed,
+gear control + reported gear, immobilizer, telltales, faults, LV/pedal/car-config)
+lives at ``/dash``. can_live is the command SURFACE + viewer: with ``--control``,
+gear/pedal/LV/car-config actions from the dashboard are FORWARDED to vehicle_sim's
+control server (``--sim-url``). vehicle_sim is the single bus owner — it transmits
+everything and runs the closed-loop responses (e.g. EPB) — so there's no two-writer
+collision and no ``--exclude`` juggling.
+
 Usage:
   python can_live.py --channel vcan0
-  python can_live.py --channel vcan0 --interface socketcan --port 8765
-  python can_live.py --channel vcan0 --replay  # replay last 100 frames for demo
+  python can_live.py --channel can0 --channel2 can1 --ui-rate 30
+  # driver HUD with gear/pedal/car-config/LV control (open http://localhost:8765/dash):
+  #   1) the sim owns the bus + serves its control server on :8770:
+  python scripts/vehicle_sim.py --channel can0 --party-channel can1
+  #   2) the viewer/HUD, forwarding /dash commands to the sim:
+  python can_live.py --channel can0 --control
 """
 
 from __future__ import annotations
@@ -14,193 +42,1023 @@ import asyncio
 import contextlib
 import json
 import logging
+import re
+import socket
+import sys
 import threading
 import time
 import webbrowser
 from pathlib import Path
 
+import aiohttp
 import can
 from aiohttp import web
 
+import alert_log
 import config as _cfg
 from can_decoder import CanDatabase
+
+sys.path.insert(0, str(Path(__file__).parent / "scripts"))
+# Reuse di.py's DI-report decode maps (for the RX side / dashboard visualization).
+# Import via the `di` PACKAGE (scripts/di/) -> di.di module; putting scripts/di
+# itself on sys.path would make di.py shadow the package and break sim_registry's
+# `from di.di_node import NODE` (di.py deliberately strips scripts/di from the path).
+# All command TX + the shared frame builders live in vehicle_sim + tesla_frames now;
+# can_live forwards commands to vehicle_sim's control server (--sim-url) and views.
+from di.di import (  # noqa: E402
+    _DI_0X118_RECOVERED,
+    DI_GEAR_LABELS,
+    DI_IMMO_LABELS,
+    DI_SYS_LABELS,
+)
 
 _STATIC_DIR = Path(__file__).parent / "can_live_ui"
 _DB: CanDatabase | None = None
 
 log = logging.getLogger("can_live")
 
-_RAW_RATE_LIMIT = 1 / 20  # minimum seconds between sends per CAN ID (~20/s max)
+# --- dashboard: DI signals we surface as a driver HUD (2020 Model3_ETH DB) -----
+# Decoded every flush tick regardless of viewer subscriptions so the dashboard
+# always has fresh state. 0x118 DI_systemStatus, 0x257 DI_speed, 0x256 DIR_status,
+# 0x2B6 DI_chassisControlStatus (the real telltale lamps: VDC / TC / vehicle-hold).
+_DASH_IDS = (0x118, 0x257, 0x256, 0x2B6)
+
+# Active alert-matrix bits are surfaced as a faults panel. Names matching these
+# hints are bench HARDWARE faults (no motor / HV / resolver wired) — flagged so
+# they read as expected, not as something CAN liveness can clear.
+_HW_FAULT_HINTS = (
+    "statorsensor",
+    "nostatorsensor",
+    "busvsensor",
+    "resolver",
+    "oilpump",
+    "linerror",
+)
+_ALERT_RE = re.compile(r"_a\d")  # alert bit signals, e.g. DIR_a050_noStatorSensor
+
+# --- alert catalog + alert log ------------------------------------------------
+# Alert-matrix bits and <NODE>_alertLog frames both identify an alert as
+# NODE_aNNN_*. The MCU alert catalog (libQtCarAlerts.so, via alert_log)
+# turns that into a human description / cause / clear / effect. It's OPTIONAL:
+# without a firmware extraction (config.ROOT) the alert panels still render,
+# they just carry the name-derived title and no prose.
+_ALERT_CAT = None
+_ALERT_CAT_ERR: str | None = None
+_ALERT_CAT_TRIED = False
+# Distinct alertLog payloads kept per bus session. An ECU re-broadcasts the same
+# logged alert continuously, so identical payloads are folded into one entry with
+# a first/last-seen instead of flooding a stream.
+_ALERT_LOG_CAP = 200
+
+# --- ODIN live cross-reference ------------------------------------------------
+# A signal counts as "on the bus now" (green in the ODIN "requires on bus" panel)
+# if the CAN frame carrying it arrived within this many seconds. Frame ARRIVAL, not
+# a decode, is the presence test -- the ODIN page holds no decoded-stream client, so
+# only arrival is reliably observed for every id (see _flusher / _api_seen_signals).
+_SEEN_WINDOW_S = 5.0
+# Only surface faults from the drive-unit ECUs. The DU also emits frames at other
+# ECUs' alert-matrix IDs (e.g. ESP 0x3D5, OCS1P 0x395); decoding those with the
+# full-car DB's ESP/OCS layouts yields PHANTOM alerts (there's no ESP/OCS on a DU
+# bench), so we ignore any alert matrix whose ECU prefix isn't a drive-unit one.
+_FAULT_ECUS = {"DIR", "DI", "PMR", "PMF", "DIF"}
+
+_DEFAULT_UI_RATE = 20.0  # flush ticks per second
+
+# Frames whose arbitration id is absent from the signal DB are forwarded to the
+# decoded view under this synthetic node rather than dropped -- see _flusher.
+# Capped so a real vehicle bus (far more ids than the DB carries) can't spray
+# hundreds of sections into the table.
+_UNKNOWN_NODE = "unknown"
+_UNKNOWN_ID_CAP = 64
+_RCVBUF_BYTES = 1 << 20  # best-effort SocketCAN receive buffer (burst headroom)
+_RECV_TIMEOUT = 0.2  # bus.recv() timeout, only bounds shutdown latency
 
 
 # ---------------------------------------------------------------------------
-# WebSocket handler
+# Frame filtering (our own bench traffic vs. the vehicle's)
 # ---------------------------------------------------------------------------
+
+
+class _TxFilter:
+    """Drops frames at the reader thread, before any buffering or decoding.
+
+    ``tx_ids`` are the IDs *our* tooling transmits (e.g. vehicle_sim.py, di.py).
+    Hidden by default when supplied, toggleable live from the UI. ``ignore_ids``
+    is the permanent version (never re-enabled).
+
+    ``hide_host_tx`` drops every frame that originated **on this host**, from any
+    local process. Note what that is not: it is not "our own socket's echo".
+    python-can derives ``is_rx`` from ``MSG_DONTROUTE``, which SocketCAN sets for
+    anything a local socket sent (``MSG_CONFIRM`` is the this-socket marker), so
+    with it on, everything vehicle_sim broadcasts disappears from the viewer
+    alongside our own sends. It is off by default for that reason, and the
+    this-socket case needs no filtering anyway: the reader never asks for
+    ``receive_own_messages``, so the kernel already withholds its own echoes.
+    """
+
+    def __init__(
+        self,
+        tx_ids: set[int],
+        ignore_ids: set[int],
+        hide_host_tx: bool,
+        tx_hidden: bool,
+    ) -> None:
+        self.tx_ids = frozenset(tx_ids)
+        self.ignore = frozenset(ignore_ids)
+        self.hide_host_tx = hide_host_tx
+        self.tx_hidden = tx_hidden
+        # Rebound (never mutated) so a reader thread always sees a consistent set.
+        self._muted: frozenset[int] = self.tx_ids if tx_hidden else frozenset()
+
+    def drop(self, msg: can.Message) -> bool:
+        if self.hide_host_tx and msg.is_rx is False:
+            return True  # created on this host (any local process), not just us
+        aid = msg.arbitration_id
+        return aid in self.ignore or aid in self._muted
+
+    def set_tx_hidden(self, hidden: bool) -> None:
+        self.tx_hidden = hidden
+        self._muted = self.tx_ids if hidden else frozenset()
+
+
+def parse_can_ids(spec: str | None) -> set[int]:
+    """Parse ``132,0x212,300-31F`` into a set of IDs. Bare values are hex."""
+    ids: set[int] = set()
+    for tok in (spec or "").replace(";", ",").replace(" ", ",").split(","):
+        tok = tok.strip()
+        if not tok:
+            continue
+        lo, _, hi = tok.partition("-")
+        start = int(lo, 16)
+        ids.update(range(start, int(hi, 16) + 1) if hi else (start,))
+    return ids
+
+
+# ---------------------------------------------------------------------------
+# Command forwarding -- can_live is the command surface; vehicle_sim is the single
+# bus owner. Gear/pedal/LV/car-config are POSTed to vehicle_sim's control server
+# (--sim-url); it mutates its VehicleController and transmits. can_live only reads
+# the bus (below) for visualization + pulls commanded state from the sim.
+# ---------------------------------------------------------------------------
+_SIM_TIMEOUT = aiohttp.ClientTimeout(total=1.5)
+
+
+async def _sim_post(app: web.Application, payload: dict) -> tuple[int, dict]:
+    """Forward a command to vehicle_sim's control server. Returns (status, json)."""
+    url = app.get("sim_url")
+    if not url:
+        return 409, {"error": "control disabled; start with --control (+ --sim-url)"}
+    try:
+        async with app["http"].post(url + "/cmd", json=payload, timeout=_SIM_TIMEOUT) as r:
+            return r.status, await r.json()
+    except Exception as e:  # noqa: BLE001
+        return 502, {"error": f"vehicle_sim unreachable at {url}: {e}"}
+
+
+async def _sim_get(app: web.Application, path: str) -> dict | None:
+    """GET JSON from vehicle_sim's control server (/state or /carconfig); None on failure."""
+    url = app.get("sim_url")
+    if not url:
+        return None
+    try:
+        async with app["http"].get(url + path, timeout=_SIM_TIMEOUT) as r:
+            if r.status == 200:
+                return await r.json()
+    except Exception:  # noqa: BLE001
+        return None
+    return None
+
+
+def _num(v: object) -> object:
+    """Round floats for JSON; pass other types through."""
+    return round(v, 2) if isinstance(v, float) else v
+
+
+def _overlay_0x118(sig: dict[str, object], data: bytes) -> None:
+    """Recover DI_immobilizerState/systemState/accelPedalPos straight from the
+    0x118 bytes at their 2020 positions — needed when a 2022+ compact.json is
+    loaded that stripped them from the DB. Reuses di.py's ``_DI_0X118_RECOVERED``.
+    Harmless when the DB already decodes them (identical raw bits)."""
+    if len(data) < 8:
+        return
+    val = int.from_bytes(bytes(data[:8]), "little")
+    for name, (sb, w) in _DI_0X118_RECOVERED.items():
+        raw = (val >> sb) & ((1 << w) - 1)
+        if name == "DI_accelPedalPos":
+            sig[name] = None if raw == 255 else raw * 0.4
+        else:
+            sig[name] = raw
+
+
+def _alert_catalog():
+    """The MCU alert catalog decoder, or None when the firmware libs are absent.
+
+    Loaded once, lazily (parsing the two .so files costs ~0.7 s), and shared with
+    can_decoder's alertLog overlay through alert_log's process-wide cache.
+    """
+    global _ALERT_CAT, _ALERT_CAT_ERR, _ALERT_CAT_TRIED
+    if _ALERT_CAT_TRIED:
+        return _ALERT_CAT
+    _ALERT_CAT_TRIED = True
+    try:
+        _ALERT_CAT = alert_log.get_decoder()
+    except Exception as e:  # noqa: BLE001 — no firmware root, missing libs, ...
+        _ALERT_CAT_ERR = str(e)
+        log.info("alert catalog unavailable (%s) — alert panels show names only", e)
+    return _ALERT_CAT
+
+
+def _faults_list(faults: dict[str, bool] | None) -> list[dict]:
+    """Active alert-matrix bits as human-readable alerts.
+
+    Each entry is a :func:`alert_log.alert_view` (title / description /
+    cause / clear / effect, or just the name-derived title with no catalog) plus
+    the bench-local ``ecu`` and ``hardware`` flags.
+    """
+    cat = _alert_catalog()
+    out = []
+    for name in sorted(k for k, v in (faults or {}).items() if v):
+        view = cat.view(name) if cat is not None else alert_log.alert_view(name)
+        view["ecu"] = view.get("node") or name.split("_", 1)[0]
+        view["hardware"] = any(h in name.lower() for h in _HW_FAULT_HINTS)
+        out.append(view)
+    return out
+
+
+def _record_alertlog(store: dict, dec, can_id: int, data: bytes, ts: float) -> None:
+    """Fold one ``<NODE>_alertLog`` frame into the distinct-payload store.
+
+    An all-zero payload is the idle "nothing logged" broadcast every ECU emits,
+    so it's skipped. ``count`` is how many flush ticks saw this exact payload as
+    the newest frame for its id — a liveness measure, not a frame count (frames
+    are coalesced per tick before we get here).
+    """
+    if not any(data):
+        return
+    key = (can_id, bytes(data))
+    ent = store.get(key)
+    if ent is None:
+        r = dec.decode(can_id, bytes(data))
+        if r is None:
+            return
+        ent = r.to_dict()
+        ent.update(key=f"{can_id:03X}:{bytes(data).hex()}", data=list(data),
+                   first=ts, last=ts, count=0)
+        store[key] = ent
+        if len(store) > _ALERT_LOG_CAP:
+            del store[min(store, key=lambda k: store[k]["last"])]
+    ent["last"] = ts
+    ent["count"] += 1
+
+
+def _build_dash_snapshot(
+    sig: dict[str, object], sim_state: dict | None, faults: dict[str, bool] | None = None
+) -> dict:
+    """DU state from the decoded bus (sig) + commanded state from vehicle_sim (sim_state)."""
+
+    def g(name: str) -> object:
+        return sig.get(name)
+
+    def as_int(name: str) -> int | None:
+        v = sig.get(name)
+        return int(v) if v is not None else None
+
+    gear_raw = as_int("DI_gear")
+    immo_raw = as_int("DI_immobilizerState")
+    sys_raw = as_int("DI_systemState")
+    limp = as_int("DIR_sysLimpRequest")
+    drive_blocked = as_int("DI_driveBlocked")
+    brake = as_int("DI_brakePedalState")
+    epb = as_int("DI_epbRequest")
+    regen = as_int("DI_regenLight")
+    # DI_chassisControlStatus 0x2B6 — the actual telltale lamps.
+    vdc_on = as_int("DI_vdcTelltaleOn")
+    vdc_flash = as_int("DI_vdcTelltaleFlash")
+    tc_on = as_int("DI_tcTelltaleOn")
+    tc_flash = as_int("DI_tcTelltaleFlash")
+    hold_on = as_int("DI_vehicleHoldTelltaleOn")
+    ptc = as_int("DI_ptcStateUI")  # 0=FAULTED 1=BACKUP 2=ON 3=SNA
+
+    telltales = [
+        {"id": "vdc", "label": "STABILITY", "level": "warn", "lit": vdc_on == 1 or vdc_flash == 1},
+        {"id": "tc", "label": "TRACTION", "level": "warn", "lit": tc_on == 1 or tc_flash == 1},
+        {"id": "hold", "label": "VEHICLE HOLD", "level": "info", "lit": hold_on == 1},
+        {"id": "ptc", "label": "PTC HEATER", "level": "danger", "lit": ptc == 0},
+        {
+            "id": "driveBlocked",
+            "label": "DRIVE BLOCKED",
+            "level": "danger",
+            "lit": bool(drive_blocked),
+        },
+        {"id": "limp", "label": "LIMP MODE", "level": "danger", "lit": limp == 1},
+        {"id": "brake", "label": "BRAKE", "level": "warn", "lit": brake in (2, 3)},
+        {"id": "parkBrake", "label": "PARK BRAKE", "level": "warn", "lit": bool(epb)},
+        {"id": "regen", "label": "REGEN", "level": "info", "lit": regen == 1},
+    ]
+
+    st = sim_state or {}
+    return {
+        "connected": any(v is not None for v in (gear_raw, immo_raw, sys_raw)),
+        "control": sim_state is not None,
+        "commanded_gear": st.get("commanded_gear"),
+        "speed_kph": _num(g("DI_vehicleSpeed")),
+        "ui_speed": as_int("DI_uiSpeed"),
+        "accel_pct": _num(g("DI_accelPedalPos")),
+        "gear": DI_GEAR_LABELS.get(gear_raw) if gear_raw is not None else None,
+        "gear_raw": gear_raw,
+        "immobilizer": DI_IMMO_LABELS.get(immo_raw) if immo_raw is not None else None,
+        "immobilizer_ok": immo_raw == 3,
+        "system_state": DI_SYS_LABELS.get(sys_raw) if sys_raw is not None else None,
+        "telltales": telltales,
+        "faults": _faults_list(faults),
+        # Commanded state comes from vehicle_sim's VehicleController (control server).
+        "lv_state": st.get("lv_state"),
+        "lv_options": st.get("lv_options", []),
+        "ui": st.get("ui"),
+        "ui_schema": st.get("ui_schema", {}),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Coalescing buffer: reader thread writes, flusher drains
+# ---------------------------------------------------------------------------
+
+
+class _BusHub:
+    """Latest-frame-per-ID buffer for one bus.
+
+    Memory is bounded by the number of distinct IDs on the bus, not by the
+    frame rate, so a burst can never grow this without limit.
+    """
+
+    def __init__(self, label: str) -> None:
+        self.label = label
+        self._lock = threading.Lock()
+        self._latest: dict[int, tuple[bytes, float]] = {}
+        self._counts: dict[int, int] = {}
+        self.rx_total = 0
+        self.coalesced = 0
+        self.errors = 0
+        # Last payload actually decoded/sent, so an unchanged frame costs a dict
+        # lookup instead of a full signal decode. Flusher-thread only.
+        self.last_sent: dict[int, bytes] = {}
+
+    def push(self, msg: can.Message) -> None:
+        aid = msg.arbitration_id
+        with self._lock:
+            if aid in self._latest:
+                self.coalesced += 1
+            self._latest[aid] = (bytes(msg.data), msg.timestamp)
+            self._counts[aid] = self._counts.get(aid, 0) + 1
+            self.rx_total += 1
+
+    def drain(self) -> tuple[dict[int, tuple[bytes, float]], dict[int, int]]:
+        with self._lock:
+            latest, counts = self._latest, self._counts
+            self._latest, self._counts = {}, {}
+        return latest, counts
+
+
+def _reader_thread(
+    hub: _BusHub,
+    bus: can.BusABC,
+    filt: _TxFilter,
+    stop: threading.Event,
+) -> None:
+    """Tight recv loop. No asyncio, no JSON, no I/O — just buffer and go back."""
+    push = hub.push
+    drop = filt.drop
+    while not stop.is_set():
+        try:
+            msg = bus.recv(timeout=_RECV_TIMEOUT)
+        except Exception:
+            if stop.is_set():
+                break
+            hub.errors += 1
+            log.debug("recv error on %s", hub.label, exc_info=True)
+            time.sleep(0.05)
+            continue
+        if msg is None or drop(msg):
+            continue
+        push(msg)
+
+
+# ---------------------------------------------------------------------------
+# Client channel: latest-wins outbox, never blocks the flusher
+# ---------------------------------------------------------------------------
+
+
+class _Channel:
+    """One WebSocket client.
+
+    ``offer()`` is non-blocking: it parks the newest batch in a single slot and
+    wakes the writer. If the browser can't keep up, the stale batch is simply
+    replaced — dropping an already-superseded snapshot costs the user nothing,
+    whereas awaiting a congested socket from the flusher would back the whole
+    pipeline up to the CAN reader.
+    """
+
+    __slots__ = ("ws", "node", "mute", "paused", "dropped", "_pending", "_wake", "_task")
+
+    def __init__(self, ws: web.WebSocketResponse) -> None:
+        self.ws = ws
+        self.node = ""  # decoded subscription; "" = every node
+        self.mute: frozenset[int] = frozenset()
+        self.paused = False
+        self.dropped = 0
+        self._pending: str | None = None
+        self._wake = asyncio.Event()
+        self._task = asyncio.create_task(self._pump())
+
+    def offer(self, payload: str) -> None:
+        if self._pending is not None:
+            self.dropped += 1
+        self._pending = payload
+        self._wake.set()
+
+    async def _pump(self) -> None:
+        try:
+            while True:
+                await self._wake.wait()
+                self._wake.clear()
+                payload, self._pending = self._pending, None
+                if payload is None:
+                    continue
+                await self.ws.send_str(payload)
+        except (asyncio.CancelledError, ConnectionResetError):
+            pass
+        except Exception:
+            log.debug("client writer stopped", exc_info=True)
+
+    async def close(self) -> None:
+        self._task.cancel()
+        with contextlib.suppress(asyncio.CancelledError, Exception):
+            await self._task
+
+
+def _reset_dedupe(app: web.Application) -> None:
+    """Force a full resend on the next tick.
+
+    A client that just connected, unmuted an ID, or resumed has no prior state,
+    so the unchanged-payload shortcut would otherwise starve it of any message
+    whose bytes happen to be static.
+    """
+    for hub in app["hubs"]:
+        hub.last_sent.clear()
+
+
+def _hello(app: web.Application) -> dict:
+    filt: _TxFilter = app["filter"]
+    return {
+        "tx_ids": sorted(filt.tx_ids),
+        "tx_hidden": filt.tx_hidden,
+        "flush_hz": round(1.0 / app["flush_interval"], 2),
+        "buses": [hub.label for hub in app["hubs"]],
+    }
+
+
+# ---------------------------------------------------------------------------
+# WebSocket handlers
+# ---------------------------------------------------------------------------
+
 
 async def _ws_handler(request: web.Request) -> web.WebSocketResponse:
-    ws = web.WebSocketResponse()
+    ws = web.WebSocketResponse(heartbeat=30.0)
     await ws.prepare(request)
 
     app = request.app
-    app["clients"].add(ws)
+    chan = _Channel(ws)
+    app["clients"].add(chan)
+    _reset_dedupe(app)
     log.info("WebSocket client connected (%d total)", len(app["clients"]))
 
-    # Send the full DB metadata so the client can populate the node list
-    await ws.send_json({"type": "db", "nodes": _DB.nodes()})
+    # Full DB metadata so the client can populate the node list
+    await ws.send_json({"type": "db", "nodes": _DB.nodes(), **_hello(app)})
 
-    subscribed: set[str] = set()
-
-    async for msg in ws:
-        if msg.type == web.WSMsgType.TEXT:
+    try:
+        async for msg in ws:
+            if msg.type != web.WSMsgType.TEXT:
+                if msg.type in (web.WSMsgType.ERROR, web.WSMsgType.CLOSE):
+                    break
+                continue
             try:
                 cmd = json.loads(msg.data)
             except json.JSONDecodeError:
                 continue
-            if cmd.get("type") == "subscribe":
+            kind = cmd.get("type")
+
+            if kind == "subscribe":
                 node = cmd.get("node", "")
-                subscribed = {node} if node else set()
+                chan.node = node
+                _reset_dedupe(app)
                 # Tell the client which message IDs belong to this node so it
                 # can pre-populate the signal table with empty rows.
-                msgs = _DB.messages_for_node(node)
-                await ws.send_json({
-                    "type": "schema",
-                    "node": node,
-                    "messages": [
-                        {
-                            "id": m["message_id"],
-                            "name": m["name"],
-                            "cycle_time": m.get("cycle_time", 0),
-                            "signals": [
-                                {
-                                    "signal": sname,
-                                    "units": sig.get("units", ""),
-                                }
-                                for sname, sig in m["signals"].items()
-                                if not sig.get("is_muxer")
-                            ],
-                        }
-                        for m in msgs
-                    ],
-                })
-                # Attach subscription info to the ws object for the reader task
-                ws["subscribed"] = subscribed
-        elif msg.type in (web.WSMsgType.ERROR, web.WSMsgType.CLOSE):
-            break
-
-    app["clients"].discard(ws)
-    log.info("WebSocket client disconnected (%d remaining)", len(app["clients"]))
+                await ws.send_json(
+                    {
+                        "type": "schema",
+                        "node": node,
+                        "messages": [
+                            {
+                                "id": m["message_id"],
+                                "name": m["name"],
+                                "cycle_time": m.get("cycle_time", 0),
+                                "signals": [
+                                    {"signal": sname, "units": sig.get("units", "")}
+                                    for sname, sig in m["signals"].items()
+                                    if not sig.get("is_muxer")
+                                ],
+                            }
+                            for m in _DB.messages_for_node(node)
+                        ],
+                    }
+                )
+            elif kind == "tx_filter":
+                _set_tx_filter(app, bool(cmd.get("on", True)))
+            elif kind == "pause":
+                chan.paused = bool(cmd.get("on", False))
+                if not chan.paused:
+                    _reset_dedupe(app)
+    finally:
+        app["clients"].discard(chan)
+        await chan.close()
+        log.info("WebSocket client disconnected (%d remaining)", len(app["clients"]))
     return ws
 
 
 async def _ws_raw_handler(request: web.Request) -> web.WebSocketResponse:
-    ws = web.WebSocketResponse()
+    ws = web.WebSocketResponse(heartbeat=30.0)
     await ws.prepare(request)
 
     app = request.app
-    app["raw_clients"].add(ws)
+    chan = _Channel(ws)
+    app["raw_clients"].add(chan)
+    _reset_dedupe(app)
     log.info("Raw WebSocket client connected (%d total)", len(app["raw_clients"]))
 
-    # Consume any incoming messages (we don't act on them) until close
-    async for msg in ws:
-        if msg.type in (web.WSMsgType.ERROR, web.WSMsgType.CLOSE):
-            break
+    await ws.send_json({"type": "hello", **_hello(app)})
 
-    app["raw_clients"].discard(ws)
-    log.info("Raw WebSocket client disconnected (%d remaining)", len(app["raw_clients"]))
+    try:
+        async for msg in ws:
+            if msg.type != web.WSMsgType.TEXT:
+                if msg.type in (web.WSMsgType.ERROR, web.WSMsgType.CLOSE):
+                    break
+                continue
+            try:
+                cmd = json.loads(msg.data)
+            except json.JSONDecodeError:
+                continue
+            kind = cmd.get("type")
+
+            if kind == "mute":
+                # Per-client: the IDs unchecked in the raw sidebar are filtered
+                # server-side so they cost no bandwidth or rendering at all.
+                chan.mute = frozenset(int(i) for i in cmd.get("ids", []))
+                _reset_dedupe(app)
+            elif kind == "pause":
+                chan.paused = bool(cmd.get("on", False))
+                if not chan.paused:
+                    _reset_dedupe(app)
+            elif kind == "tx_filter":
+                _set_tx_filter(app, bool(cmd.get("on", True)))
+    finally:
+        app["raw_clients"].discard(chan)
+        await chan.close()
+        log.info("Raw WebSocket client disconnected (%d remaining)", len(app["raw_clients"]))
     return ws
 
 
+def _set_tx_filter(app: web.Application, hidden: bool) -> None:
+    """Global (both tabs, all clients) — it's a statement about what the traffic
+    *is*, not a per-view preference."""
+    filt: _TxFilter = app["filter"]
+    if filt.tx_hidden == hidden:
+        return
+    filt.set_tx_hidden(hidden)
+    _reset_dedupe(app)
+    log.info("TX filter %s (%d ids)", "on" if hidden else "off", len(filt.tx_ids))
+    payload = json.dumps({"type": "tx_filter", "on": hidden, "tx_ids": sorted(filt.tx_ids)})
+    for chan in (*app["clients"], *app["raw_clients"]):
+        with contextlib.suppress(Exception):
+            asyncio.create_task(chan.ws.send_str(payload))
+
+
 # ---------------------------------------------------------------------------
-# CAN reader task
+# Flusher: drain -> decode (only what's subscribed) -> batch -> fan out
 # ---------------------------------------------------------------------------
 
-async def _can_reader(app: web.Application, bus: can.BusABC) -> None:
-    loop = asyncio.get_running_loop()
-    raw_last_sent: dict[int, float] = {}  # CAN ID -> monotonic timestamp of last raw send
 
-    def _read_one() -> can.Message | None:
-        return bus.recv(timeout=0.1)
+def _fanout_raw(clients: list[_Channel], frames: list[dict], rx: int) -> None:
+    shared: str | None = None
+    for chan in clients:
+        if chan.mute:
+            sel = [f for f in frames if f["id"] not in chan.mute]
+            if not sel:
+                continue
+            chan.offer(json.dumps({"type": "frames", "frames": sel, "rx": rx}))
+        else:
+            if shared is None:
+                shared = json.dumps({"type": "frames", "frames": frames, "rx": rx})
+            chan.offer(shared)
+
+
+def _fanout_decoded(clients: list[_Channel], frames: list[dict], rx: int) -> None:
+    shared: str | None = None
+    by_node: dict[str, str] = {}
+    for chan in clients:
+        if chan.node:
+            payload = by_node.get(chan.node)
+            if payload is None:
+                sel = [f for f in frames if f["node"] == chan.node]
+                if not sel:
+                    continue
+                payload = json.dumps({"type": "frames", "frames": sel, "rx": rx})
+                by_node[chan.node] = payload
+            chan.offer(payload)
+        else:
+            if shared is None:
+                shared = json.dumps({"type": "frames", "frames": frames, "rx": rx})
+            chan.offer(shared)
+
+
+async def _flusher(app: web.Application) -> None:
+    hubs: list[_BusHub] = app["hubs"]
+    interval: float = app["flush_interval"]
+    messages = _DB.messages
+    decode = _DB.decode_frame
+
+    dash_sig: dict[str, object] = app["dash_sig"]
+    faults: dict[str, bool] = app["faults"]
+    alert_ids: dict[int, str] = app["alert_ids"]
+    alertlog_store: dict = app["alert_log"]  # not `alert_log` — that's the module
+    alert_dec = app["alert_decoder"]
+    alertlog_ids = app["alertlog_ids"]
+    seen_msg: dict[int, float] = app["seen_msg"]
+    show_unknown: bool = app["show_unknown"]
+    unknown_ids: set[int] = set()   # ids not in the DB, already announced
+    unknown_capped = False
 
     while True:
-        msg = await loop.run_in_executor(None, _read_one)
-        if msg is None:
-            continue
+        await asyncio.sleep(interval)
+        now = time.monotonic()
 
-        # --- Raw broadcast (all frames, rate-limited per ID) ---
-        if app["raw_clients"]:
-            now = time.monotonic()
-            arb_id = msg.arbitration_id
-            if now - raw_last_sent.get(arb_id, 0.0) >= _RAW_RATE_LIMIT:
-                raw_last_sent[arb_id] = now
-                raw_payload = json.dumps({
-                    "id": arb_id,
-                    "data": list(msg.data),
-                    "ts": msg.timestamp,
-                })
-                dead_raw: set[web.WebSocketResponse] = set()
-                for rws in list(app["raw_clients"]):
-                    try:
-                        await rws.send_str(raw_payload)
-                    except Exception:
-                        dead_raw.add(rws)
-                app["raw_clients"].difference_update(dead_raw)
+        raw_clients = [c for c in app["raw_clients"] if not c.paused]
+        dec_clients = [c for c in app["clients"] if not c.paused]
+        want_raw = bool(raw_clients)
+        want_dec = bool(dec_clients)
+        # "" subscription means every node; otherwise decode only what's wanted.
+        wants_all = want_dec and any(not c.node for c in dec_clients)
+        wanted = {c.node for c in dec_clients if c.node}
 
-        # --- Decoded broadcast (DBC frames only) ---
-        decoded = _DB.decode_frame(msg.arbitration_id, bytes(msg.data))
-        if decoded is None:
-            continue
+        raw_frames: list[dict] = []
+        dec_frames: list[dict] = []
+        rx = 0
 
-        db_msg = _DB.messages.get(msg.arbitration_id)
-        if db_msg is None:
-            continue
+        for hub in hubs:
+            latest, counts = hub.drain()  # always drain, even with no clients
+            # ODIN live cross-reference: stamp every arriving id, regardless of viewer
+            # subscriptions, so the "requires on bus" panel can mark signals present.
+            for aid in latest:
+                seen_msg[aid] = now
+            # Dashboard: decode the handful of DI status IDs every tick, regardless
+            # of viewer subscriptions, so the HUD stays live even with no WS client.
+            for aid in _DASH_IDS:
+                cell = latest.get(aid)
+                if cell is None:
+                    continue
+                dec = decode(aid, cell[0])
+                if dec:
+                    for s in dec:
+                        dash_sig[s["signal"]] = s["value"]
+                if aid == 0x118:
+                    _overlay_0x118(dash_sig, cell[0])
+            # Faults: accumulate active alert-matrix bits (muxed -> update per page
+            # as it cycles). Runs every tick regardless of viewer subscriptions.
+            for aid, cell in latest.items():
+                if aid in alert_ids:
+                    for s in decode(aid, cell[0]) or []:
+                        if _ALERT_RE.search(s["signal"]):
+                            faults[s["signal"]] = bool(s["value"])
+                # <NODE>_alertLog: the ECU's own log of WHY an alert was raised
+                # (for CAN-rationality alerts, the offending id + error type).
+                # No sim node transmits these, so anything seen here is a real ECU.
+                elif aid in alertlog_ids:
+                    _record_alertlog(alertlog_store, alert_dec, aid, cell[0], cell[1])
+            if not (want_raw or want_dec):
+                continue
+            label = hub.label
+            last_sent = hub.last_sent
+            for aid, (data, ts) in latest.items():
+                n = counts[aid]
+                rx += n
+                # A byte-identical payload cannot change any displayed value, so
+                # it's forwarded as a bare liveness tick: no decode, no signal
+                # list, no byte array. Keeps age/rate honest for the many frames
+                # that only repeat a static status.
+                unchanged = last_sent.get(aid) == data
+                if not unchanged:
+                    last_sent[aid] = data
 
-        node = db_msg.get("originNode", "")
-        payload = json.dumps({
-            "type": "frame",
-            "node": node,
-            "msg_id": msg.arbitration_id,
-            "msg_name": db_msg["name"],
-            "timestamp": msg.timestamp,
-            "signals": decoded,
-        })
+                if want_raw:
+                    frame = {"id": aid, "ts": ts, "bus": label, "n": n}
+                    if not unchanged:
+                        frame["data"] = list(data)
+                    raw_frames.append(frame)
 
-        dead: set[web.WebSocketResponse] = set()
-        for ws in list(app["clients"]):
-            sub = getattr(ws, "__dict__", {}).get("subscribed") or ws.get("subscribed", set())
-            if not sub or node in sub:
-                try:
-                    await ws.send_str(payload)
-                except Exception:
-                    dead.add(ws)
+                if not want_dec:
+                    continue
+                db_msg = messages.get(aid)
+                if db_msg is None:
+                    # Not in the DB. Forwarded undecoded rather than dropped: a
+                    # silently hidden frame is exactly how a node that IS
+                    # transmitting comes to look dead in the viewer (the sim
+                    # gained ids the compact JSON doesn't carry, and its nodes
+                    # went dark). No originNode to match a subscription against,
+                    # so these only go to unfiltered clients.
+                    if show_unknown and wants_all:
+                        if aid not in unknown_ids:
+                            if len(unknown_ids) >= _UNKNOWN_ID_CAP:
+                                if not unknown_capped:
+                                    log.warning(
+                                        "unknown-id cap reached (%d): further ids absent from "
+                                        "the DB are dropped from the decoded view. Raw Frames "
+                                        "still shows everything.", _UNKNOWN_ID_CAP,
+                                    )
+                                    unknown_capped = True
+                                continue
+                            unknown_ids.add(aid)
+                            log.info("id 0x%03X on %s is not in the signal DB -- "
+                                     "showing it undecoded", aid, label)
+                        frame = {
+                            "node": _UNKNOWN_NODE, "msg_id": aid, "timestamp": ts,
+                            "bus": label, "n": n, "unknown": 1,
+                        }
+                        if unchanged:
+                            frame["same"] = 1
+                        else:
+                            frame["data"] = list(data)
+                        dec_frames.append(frame)
+                    continue
+                node = db_msg.get("originNode", "")
+                if not wants_all and node not in wanted:
+                    continue  # skip the decode entirely — the expensive part
+                if unchanged:
+                    dec_frames.append(
+                        {
+                            "node": node,
+                            "msg_id": aid,
+                            "timestamp": ts,
+                            "bus": label,
+                            "n": n,
+                            "same": 1,
+                        }
+                    )
+                    continue
+                decoded = decode(aid, data)
+                if decoded is None:
+                    continue
+                dec_frames.append(
+                    {
+                        "node": node,
+                        "msg_id": aid,
+                        "msg_name": db_msg["name"],
+                        "timestamp": ts,
+                        "signals": decoded,
+                        "bus": label,
+                        "n": n,
+                    }
+                )
 
-        app["clients"].difference_update(dead)
+        if raw_frames:
+            _fanout_raw(raw_clients, raw_frames, rx)
+        if dec_frames:
+            _fanout_decoded(dec_clients, dec_frames, rx)
 
 
 # ---------------------------------------------------------------------------
 # Startup / cleanup
 # ---------------------------------------------------------------------------
 
+
 async def _start_reader(app: web.Application) -> None:
     app["clients"] = set()
     app["raw_clients"] = set()
-    bus: can.BusABC = app["bus"]
-    app["reader_task"] = asyncio.create_task(_can_reader(app, bus))
+    app["http"] = aiohttp.ClientSession()  # for forwarding commands to vehicle_sim
+    app["dash_sig"] = {}  # latest decoded DI signals for the driver HUD
+    app["faults"] = {}  # alert-matrix bit name -> currently-set bool
+    app["seen_msg"] = {}  # CAN id -> last-arrival monotonic (ODIN live cross-ref)
+    # CAN id -> the signal names it carries; a signal is "seen" when its id arrives.
+    app["msg_signals"] = {mid: tuple(m["signals"].keys()) for mid, m in _DB.messages.items()}
+    app["alert_ids"] = {
+        mid: m["name"]
+        for mid, m in _DB.messages.items()
+        if "alertmatrix" in m["name"].lower() and m["name"].split("_", 1)[0] in _FAULT_ECUS
+    }
+    # Alert log: distinct decoded payloads, keyed (can_id, bytes). The catalog is
+    # loaded here (once, at startup) rather than on the first HTTP poll so the
+    # ~0.7 s .so parse never lands inside a request.
+    app["alert_log"] = {}
+    app["alert_decoder"] = _alert_catalog()
+    app["alertlog_ids"] = frozenset(
+        app["alert_decoder"].alertlog_node) if app["alert_decoder"] else frozenset()
+    app["stop"] = threading.Event()
+    app["threads"] = [
+        threading.Thread(
+            target=_reader_thread,
+            args=(hub, bus, app["filter"], app["stop"]),
+            name=f"can-rx-{hub.label}",
+            daemon=True,
+        )
+        for bus, hub in app["sources"]
+    ]
+    for t in app["threads"]:
+        t.start()
+    app["flusher"] = asyncio.create_task(_flusher(app))
+    app["stats"] = asyncio.create_task(_stats_logger(app))
+
+
+async def _stats_logger(app: web.Application) -> None:
+    hubs: list[_BusHub] = app["hubs"]
+    prev = {hub.label: (0, 0) for hub in hubs}
+    while True:
+        await asyncio.sleep(10.0)
+        for hub in hubs:
+            p_rx, p_co = prev[hub.label]
+            rx, co = hub.rx_total, hub.coalesced
+            prev[hub.label] = (rx, co)
+            if rx != p_rx:
+                log.info(
+                    "%s: %.0f frame/s in, %.0f%% coalesced for display",
+                    hub.label,
+                    (rx - p_rx) / 10.0,
+                    100.0 * (co - p_co) / max(1, rx - p_rx),
+                )
 
 
 async def _stop_reader(app: web.Application) -> None:
-    task: asyncio.Task = app["reader_task"]
-    task.cancel()
-    with contextlib.suppress(asyncio.CancelledError):
-        await task
-    app["bus"].shutdown()
+    app["stop"].set()
+    for task_key in ("flusher", "stats"):
+        task = app.get(task_key)
+        if task is not None:
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+    if app.get("http") is not None:
+        await app["http"].close()
+    if app.get("odin_bench") is not None:
+        with contextlib.suppress(Exception):
+            app["odin_bench"].close()  # stop ODIN's UDS TesterPresent + shut its sockets
+    for chan in (*app["clients"], *app["raw_clients"]):
+        await chan.close()
+    for t in app["threads"]:
+        t.join(timeout=_RECV_TIMEOUT * 5)
+    for bus, _hub in app["sources"]:
+        with contextlib.suppress(Exception):
+            bus.shutdown()
 
 
 # ---------------------------------------------------------------------------
 # Static frontend
 # ---------------------------------------------------------------------------
 
+
 async def _index(request: web.Request) -> web.FileResponse:
     return web.FileResponse(_STATIC_DIR / "index.html")
+
+
+async def _alerts_js(request: web.Request) -> web.FileResponse:
+    """The alert renderer shared by the viewer and the HUD (can_live_ui/alerts.js)."""
+    return web.FileResponse(_STATIC_DIR / "alerts.js")
+
+
+# ---------------------------------------------------------------------------
+# Dashboard (driver HUD) — separate page, same backend
+# ---------------------------------------------------------------------------
+
+
+async def _dash_index(request: web.Request) -> web.FileResponse:
+    return web.FileResponse(_STATIC_DIR / "dash.html")
+
+
+# ---------------------------------------------------------------------------
+# ODIN (procedure runner + DID read/write) — endpoints only; the ODIN and DID
+# panes are tabs on the main viewer page (can_live_ui/index.html).
+# ---------------------------------------------------------------------------
+
+
+def _odin_backend(app: web.Application):
+    """Lazily build the shared ODIN bench backend on the configured VEHICLE bus
+    (config.VEHICLE_CHANNEL / TM3_VEHICLE_CHANNEL), falling back to can_live's own
+    --channel. ODIN transmits UDS, so it needs a CONCRETE interface: can_live can
+    read on the socketcan 'any' interface (an empty channel), but UDS TX cannot.
+    Shared by procedure runs (backend_factory) + DID ops (node_provider); closed in
+    _stop_reader. Lazy import so a view-only can_live pays nothing."""
+    be = app.get("odin_bench")
+    if be is None:
+        import odin_runner
+
+        channel = _cfg.VEHICLE_CHANNEL or app.get("can_channel")
+        if not channel:
+            raise RuntimeError(
+                "ODIN needs a concrete vehicle CAN channel to transmit UDS. Set the "
+                "config bus TM3_VEHICLE_CHANNEL, or start can_live with --channel "
+                "<iface> (can_live reads on the 'any' interface, but UDS TX cannot)."
+            )
+        be = odin_runner.BenchBackend(channel, app.get("can_interface") or "socketcan")
+        app["odin_bench"] = be
+    return be
+
+
+async def _api_dash(request: web.Request) -> web.Response:
+    """DI HUD snapshot: DU state from the bus + commanded state from vehicle_sim."""
+    app = request.app
+    sim_state = await _sim_get(app, "/state")
+    return web.json_response(_build_dash_snapshot(app["dash_sig"], sim_state, app.get("faults")))
+
+
+async def _api_alerts(request: web.Request) -> web.Response:
+    """Human-readable alerts: active alert-matrix bits + the decoded alert log.
+
+    ``faults`` are the alert bits currently SET on the bus; ``log`` is what the
+    ECUs logged about them (newest first). Both carry the MCU catalog's
+    description / cause / clear / effect when a firmware root is configured --
+    ``catalog`` says whether that text is available at all.
+    """
+    app = request.app
+    log_entries = sorted(app.get("alert_log", {}).values(),
+                         key=lambda e: e["last"], reverse=True)
+    return web.json_response({
+        "catalog": app.get("alert_decoder") is not None,
+        "catalog_error": _ALERT_CAT_ERR,
+        "faults": _faults_list(app.get("faults")),
+        "log": log_entries,
+    })
+
+
+async def _api_alerts_clear(request: web.Request) -> web.Response:
+    """POST — drop the accumulated alert log (and the latched fault bits).
+
+    Alert bits only clear when the ECU clears them, and a logged payload stays in
+    the store until evicted, so a bench run that fixed the cause needs a way to
+    start the picture over rather than reading stale history.
+    """
+    app = request.app
+    app.get("alert_log", {}).clear()
+    app.get("faults", {}).clear()
+    return web.json_response({"ok": True})
+
+
+async def _api_seen_signals(request: web.Request) -> web.Response:
+    """Signal names whose carrying CAN frame arrived within the freshness window --
+    the live cross-reference behind the ODIN 'requires on bus' green/red badges.
+    Optional ?window=<seconds> overrides the default staleness cutoff."""
+    app = request.app
+    seen_msg: dict[int, float] = app.get("seen_msg", {})
+    msg_signals: dict[int, tuple] = app.get("msg_signals", {})
+    try:
+        window = float(request.query.get("window", _SEEN_WINDOW_S))
+    except (TypeError, ValueError):
+        window = _SEEN_WINDOW_S
+    now = time.monotonic()
+    names: set[str] = set()
+    for aid, ts in seen_msg.items():
+        if now - ts <= window:
+            names.update(msg_signals.get(aid, ()))
+    return web.json_response({"signals": sorted(names), "window": window})
+
+
+async def _forward_cmd(request: web.Request, cmd_type: str) -> web.Response:
+    """Read the POST body, tag it with the command type, forward to vehicle_sim."""
+    try:
+        body = await request.json()
+    except Exception:  # noqa: BLE001
+        return web.json_response({"error": "invalid JSON"}, status=400)
+    status, resp = await _sim_post(request.app, {"type": cmd_type, **body})
+    return web.json_response(resp, status=status)
+
+
+async def _api_gear(request: web.Request) -> web.Response:
+    """POST {"value":"P|R|N|D"} — actuate the SCCM stalk gesture (via vehicle_sim)."""
+    return await _forward_cmd(request, "gear")
+
+
+async def _api_ui(request: web.Request) -> web.Response:
+    """POST {"field":"pedal_map","value":"sport"} — set a UiConfig setting (via sim)."""
+    return await _forward_cmd(request, "ui")
+
+
+async def _api_lv(request: web.Request) -> web.Response:
+    """POST {"value":"off|conditioning|accessory|drive"} — set LV power (via sim)."""
+    return await _forward_cmd(request, "lv")
+
+
+async def _api_carconfig(request: web.Request) -> web.Response:
+    """GET the GTW_carConfig schema (from vehicle_sim); POST {"signal","value"} to set."""
+    if request.method == "GET":
+        sch = await _sim_get(request.app, "/carconfig")
+        if sch is None:
+            return web.json_response({"error": "vehicle_sim unreachable"}, status=502)
+        return web.json_response(sch)
+    return await _forward_cmd(request, "carconfig")
 
 
 async def _api_db(request: web.Request) -> web.Response:
@@ -213,17 +1071,21 @@ async def _api_db(request: web.Request) -> web.Response:
                 {
                     "name": sname,
                     "units": sig.get("units", ""),
-                    "values": list(sig["value_description"].keys()) if sig.get("value_description") else [],
+                    "values": list(sig["value_description"].keys())
+                    if sig.get("value_description")
+                    else [],
                 }
                 for sname, sig in m["signals"].items()
                 if not sig.get("is_muxer")
             ]
-            msgs.append({
-                "id": m["message_id"],
-                "name": m["name"],
-                "cycle_time": m.get("cycle_time", 0),
-                "signals": signals,
-            })
+            msgs.append(
+                {
+                    "id": m["message_id"],
+                    "name": m["name"],
+                    "cycle_time": m.get("cycle_time", 0),
+                    "signals": signals,
+                }
+            )
         payload[node] = msgs
     return web.json_response(payload)
 
@@ -232,16 +1094,65 @@ async def _api_db(request: web.Request) -> web.Response:
 # Entry point
 # ---------------------------------------------------------------------------
 
-def _build_app(bus: can.BusABC) -> web.Application:
+
+def _build_app(
+    buses: list[tuple[can.BusABC, str]],
+    filt: _TxFilter,
+    ui_rate: float,
+    sim_url: str | None = None,
+    channel: str | None = None,
+    interface: str = "socketcan",
+    show_unknown: bool = True,
+) -> web.Application:
     app = web.Application()
-    app["bus"] = bus
+    sources = [(bus, _BusHub(label)) for bus, label in buses]
+    app["sources"] = sources
+    app["hubs"] = [hub for _bus, hub in sources]
+    app["filter"] = filt
+    app["sim_url"] = sim_url  # vehicle_sim control server, or None (view-only)
+    app["can_channel"] = channel  # for the ODIN's bench backend
+    app["can_interface"] = interface
+    app["flush_interval"] = 1.0 / max(1.0, ui_rate)
+    app["show_unknown"] = show_unknown
     app.on_startup.append(_start_reader)
     app.on_cleanup.append(_stop_reader)
     app.router.add_get("/", _index)
+    app.router.add_get("/dash", _dash_index)
+    app.router.add_get("/alerts.js", _alerts_js)
     app.router.add_get("/api/db", _api_db)
+    app.router.add_get("/api/dash", _api_dash)
+    app.router.add_get("/api/alerts", _api_alerts)
+    app.router.add_post("/api/alerts/clear", _api_alerts_clear)
+    app.router.add_get("/api/seen-signals", _api_seen_signals)
+    app.router.add_post("/api/gear", _api_gear)
+    app.router.add_post("/api/ui", _api_ui)
+    app.router.add_post("/api/lv", _api_lv)
+    app.router.add_get("/api/carconfig", _api_carconfig)
+    app.router.add_post("/api/carconfig", _api_carconfig)
     app.router.add_get("/ws", _ws_handler)
     app.router.add_get("/ws-raw", _ws_raw_handler)
+    # ODIN: procedure list/run (+ /ws/odin progress), DID read/write, and the
+    # low-level UDS ops -- all driven from the ODIN/DID tabs on the viewer page.
+    # Runs against a lazily-built bench backend (this app's CAN channel); see
+    # scripts/odin_web.py. can_live keeps only the viewer/HUD.
+    import odin_web
+
+    odin_web.setup_routes(
+        app,
+        bundle=_cfg.ODIN_BUNDLE,
+        backend_factory=lambda: _odin_backend(app),
+        node_provider=lambda node: _odin_backend(app).open_node(node),
+    )
     return app
+
+
+def _tune_rx_buffer(bus: can.BusABC) -> None:
+    """Give SocketCAN burst headroom so a scheduling hiccup doesn't drop frames."""
+    sock = getattr(bus, "socket", None)
+    if sock is None:
+        return
+    with contextlib.suppress(OSError, AttributeError):
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF, _RCVBUF_BYTES)
 
 
 def main() -> None:
@@ -249,10 +1160,70 @@ def main() -> None:
     parser.add_argument("--channel", help="CAN channel")
     parser.add_argument("--interface", help="python-can interface")
     parser.add_argument("--bitrate", type=int, default=None, help="CAN bitrate (optional)")
+    parser.add_argument(
+        "--channel2",
+        default=None,
+        help="optional 2nd CAN channel to also read (e.g. party/private bus)",
+    )
+    parser.add_argument(
+        "--interface2", default=None, help="interface for --channel2 (defaults to --interface)"
+    )
+    parser.add_argument(
+        "--bitrate2", type=int, default=None, help="bitrate for --channel2 (defaults to --bitrate)"
+    )
     _cfg.apply_defaults(parser)
     parser.add_argument("--port", type=int, default=8765, help="HTTP port (default: 8765)")
     parser.add_argument("--no-browser", action="store_true", help="Don't auto-open browser")
-    parser.add_argument("--dbc", type=Path, default=None, help="Load a DBC file instead of the default compact JSON")
+    parser.add_argument(
+        "--dbc", type=Path, default=None, help="Load a DBC file instead of the default compact JSON"
+    )
+    parser.add_argument(
+        "--ui-rate",
+        type=float,
+        default=_DEFAULT_UI_RATE,
+        help=f"UI update rate in Hz (default: {_DEFAULT_UI_RATE:.0f}); "
+        "frames are coalesced per ID between ticks",
+    )
+    parser.add_argument(
+        "--tx-ids",
+        default=None,
+        help="comma-separated IDs our own tools transmit (hex, e.g. "
+        "132,212,25D,221,3A1) — hidden by default, toggleable in the UI",
+    )
+    parser.add_argument(
+        "--ignore-ids",
+        default=None,
+        help="comma-separated IDs to drop permanently (hex; ranges like 700-7FF ok)",
+    )
+    parser.add_argument(
+        "--show-tx",
+        action="store_true",
+        help="start with --tx-ids traffic visible instead of hidden",
+    )
+    parser.add_argument(
+        "--hide-unknown",
+        action="store_true",
+        help="drop frames whose id is not in the signal DB instead of showing "
+        "them undecoded under an 'unknown' node",
+    )
+    parser.add_argument(
+        "--hide-host-tx",
+        action="store_true",
+        help="drop every frame originated on this host — including everything "
+        "vehicle_sim broadcasts, not just this process's sends",
+    )
+    parser.add_argument(
+        "--control",
+        action="store_true",
+        help="enable the driver HUD's controls: gear/pedal/LV/car-config commands "
+        "from /dash are FORWARDED to vehicle_sim's control server (--sim-url), "
+        "which owns the bus and transmits. Run vehicle_sim.py alongside.",
+    )
+    parser.add_argument(
+        "--sim-url",
+        default="http://localhost:8770",
+        help="vehicle_sim control server URL for --control (default localhost:8770)",
+    )
     args = parser.parse_args()
 
     logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
@@ -264,24 +1235,72 @@ def main() -> None:
     else:
         _DB = CanDatabase()
 
-    kwargs: dict = {"channel": args.channel, "interface": args.interface}
-    if args.bitrate:
-        kwargs["bitrate"] = args.bitrate
+    def _open(channel: str, interface: str, bitrate: int | None) -> can.BusABC:
+        kw: dict = {"channel": channel, "interface": interface}
+        if bitrate:
+            kw["bitrate"] = bitrate
+        b = can.Bus(**kw)
+        _tune_rx_buffer(b)
+        log.info("Opened CAN bus: %s on %s", channel, interface)
+        return b
 
-    bus = can.Bus(**kwargs)
-    log.info("Opened CAN bus: %s on %s", args.channel, args.interface)
+    # Buses come from the config vehicle/party channels (config.CAN_CHANNELS) unless
+    # overridden by --channel/--channel2, so the viewer + the ODIN agree on one
+    # concrete bus (an empty channel binds socketcan to 'any' -- reads work, UDS TX
+    # doesn't). label each bus by its channel name so the UI can tell them apart.
+    channel = args.channel or _cfg.VEHICLE_CHANNEL
+    interface = args.interface or "socketcan"
+    if not channel:
+        parser.error("no CAN channel: pass --channel or set TM3_VEHICLE_CHANNEL (config bus)")
+    buses = [(_open(channel, interface, args.bitrate), channel)]
+    channel2 = args.channel2 or _cfg.PARTY_CHANNEL
+    if channel2:
+        buses.append(
+            (
+                _open(channel2, args.interface2 or interface, args.bitrate2 or args.bitrate),
+                channel2,
+            )
+        )
 
-    app = _build_app(bus)
+    tx_ids = parse_can_ids(args.tx_ids)
+    sim_url = None
+    if args.control:
+        sim_url = args.sim_url.rstrip("/")
+        log.info(
+            "Control ENABLED: /dash gear/pedal/LV/car-config -> vehicle_sim at %s "
+            "(it owns the bus + transmits). Drive from %s/dash.",
+            sim_url,
+            f"http://localhost:{args.port}",
+        )
+    filt = _TxFilter(
+        tx_ids=tx_ids,
+        ignore_ids=parse_can_ids(args.ignore_ids),
+        hide_host_tx=args.hide_host_tx,
+        tx_hidden=bool(tx_ids) and not args.show_tx,
+    )
+    if tx_ids:
+        log.info(
+            "TX filter: %d ids %s",
+            len(tx_ids),
+            "hidden" if filt.tx_hidden else "visible (--show-tx)",
+        )
+
+    app = _build_app(buses, filt, args.ui_rate, sim_url, channel=channel,
+                     interface=interface, show_unknown=not args.hide_unknown)
 
     url = f"http://localhost:{args.port}"
-    in_wsl = Path("/proc/version").exists() and "microsoft" in Path("/proc/version").read_text().lower()
+    in_wsl = (
+        Path("/proc/version").exists() and "microsoft" in Path("/proc/version").read_text().lower()
+    )
     if not args.no_browser and not in_wsl:
+
         def _open_browser() -> None:
             if not webbrowser.open(url):
                 log.info("Could not open browser automatically — visit %s", url)
+
         threading.Timer(0.5, _open_browser).start()
 
-    log.info("Serving on %s", url)
+    log.info("Serving on %s (UI %.0f Hz)", url, args.ui_rate)
     web.run_app(app, host="0.0.0.0", port=args.port, print=None)
 
 

--- a/can_live_ui/alerts.js
+++ b/can_live_ui/alerts.js
@@ -1,0 +1,190 @@
+/* Shared alert rendering for the CAN Live viewer (/) and the Drive HUD (/dash).
+ *
+ * Both pages consume the same /api/alerts payload:
+ *   faults[] — alert-matrix bits currently SET on the bus
+ *   log[]    — distinct <NODE>_alertLog payloads the ECUs broadcast, decoded
+ * and both entry kinds are the same shape (alert_log.alert_view: title,
+ * description, cause, clear, effect + the raw NODE_aNNN_name), so one renderer
+ * serves both. Only the CSS lives per page — each defines .fault / .alog-row /
+ * .a-sec against its own palette variables.
+ */
+(function () {
+  const ESC = { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' };
+  // Alert text is firmware-derived, so it goes through innerHTML escaped.
+  const esc = s => String(s == null ? '' : s).replace(/[&<>"]/g, c => ESC[c]);
+  const hex3 = n => '0x' + Number(n).toString(16).toUpperCase().padStart(3, '0');
+  const bytes = arr => (arr || []).map(b => b.toString(16).toUpperCase().padStart(2, '0')).join(' ');
+
+  function fmtTime(ts) {
+    if (!ts) return '';
+    return new Date(ts * 1000).toLocaleTimeString(undefined, { hour12: false });
+  }
+
+  // One-line "why the ECU logged this" for a decoded alertLog entry: the
+  // offending message for CAN-rationality alerts, the decoded reason enum for
+  // everything else that has one, else the raw payload words.
+  function logWhy(e) {
+    if (e.rationality && e.offending_id != null) {
+      const who = e.offending_name || hex3(e.offending_id);
+      const bad = e.bad_value1 != null ? ` (bad ${e.bad_value1}/${e.bad_value2})` : '';
+      return `${who} · ${e.error_name || 'error ' + e.error_type}${bad}`;
+    }
+    if (e.reason_label) return e.reason_label;
+    if (e.reason_text) return e.reason_text;
+    return e.words && e.words.length
+      ? 'words ' + e.words.map(w => w.toString(16).toUpperCase().padStart(4, '0')).join(' ')
+      : '';
+  }
+
+  // Tooltip text: Tesla's own description, falling back to the trigger condition.
+  function tooltip(a) {
+    const head = `${a.name}${a.ecu && !a.name.startsWith(a.ecu) ? ' (' + a.ecu + ')' : ''}`;
+    const body = a.description || a.cause || '';
+    return body ? `${head}\n\n${body}` : head;
+  }
+
+  function section(heading, text) {
+    return text ? `<div class="a-sec"><h3>${esc(heading)}</h3><p>${esc(text)}</p></div>` : '';
+  }
+
+  // Full detail body for the modal. Works for a fault bit and for a log entry —
+  // a log entry just carries the extra payload fields.
+  function detailHtml(a) {
+    const out = [];
+    // The decoded reason goes first — it's the one field that says which of the
+    // alert's many possible triggers actually fired on this frame.
+    if (a.reason_signal) {
+      const short = a.reason_signal.replace(/^[A-Z][A-Z0-9]*_[a-z]{1,2}\d+_/, '');
+      out.push('<div class="a-sec"><h3>Reason</h3><p><b>'
+        + esc(a.reason_label || a.reason_value) + '</b>'
+        + `<span class="hint"> — ${esc(short)}`
+        + (a.reason_label ? '' : ' (value not in the catalog’s table)') + '</span></p></div>');
+    }
+    out.push(
+      section('What it means', a.description),
+      section('Cause', a.cause),
+      section('Clears when', a.clear),
+      section('Effect', a.effect),
+    );
+    if (!a.description && !a.cause && !a.clear && !a.effect) {
+      out.push('<div class="a-sec"><p class="hint">No catalog text for this alert in the '
+        + 'loaded firmware build — the title above is derived from the alert name. Point '
+        + 'TM3_ROOT at a firmware extraction to get Tesla’s own description.</p></div>');
+    }
+
+    if (a.data) {
+      // Every logged signal is listed, decoded or not: the undecoded ones say
+      // what the remaining payload words mean even though their bit positions
+      // aren't published anywhere (see alert_log's module docstring).
+      const undec = (a.log_values || []).filter(v => v.value == null).length;
+      const kv = (a.log_values || []).map(v => `<dt>${esc(v.name)}</dt><dd>`
+        + (v.value == null ? '<span class="hint">not decoded</span>' : esc(v.value))
+        + '</dd>').join('');
+      out.push('<div class="a-sec"><h3>Logged by the ECU</h3>'
+        + `<div class="a-code"><b>${esc(hex3(a.can_id))}</b> · ${esc(bytes(a.data))}`
+        + (a.state ? ` · <b>${esc(a.state)}</b>` : '') + '</div>'
+        + (kv ? `<dl class="a-kv" style="margin-top:8px">${kv}</dl>` : '')
+        + (undec ? '<p class="hint" style="margin-top:6px">'
+            + `${undec} field${undec > 1 ? 's have' : ' has'} no published bit layout — `
+            + 'the raw payload above carries them.</p>' : '')
+        + '</div>');
+      out.push('<div class="a-sec"><h3>Seen</h3><dl class="a-kv">'
+        + `<dt>first</dt><dd>${esc(fmtTime(a.first))}</dd>`
+        + `<dt>last</dt><dd>${esc(fmtTime(a.last))}</dd>`
+        + `<dt>ticks</dt><dd>${esc(a.count)}</dd></dl></div>`);
+    } else if (a.log_signals && a.log_signals.length) {
+      // A fault bit with no log frame captured yet: still say which signals the
+      // ECU would log, so you know what to watch for on the alertLog id.
+      out.push('<div class="a-sec"><h3>Logs these signals</h3><div class="a-code">'
+        + esc(a.log_signals.join(', ')) + '</div></div>');
+    }
+
+    const extra = [];
+    if (a.catalog_name && a.catalog_name !== a.name) extra.push('catalog: ' + a.catalog_name);
+    if (a.audience) extra.push('audience ' + a.audience);
+    out.push('<div class="a-sec"><h3>Alert code</h3><div class="a-code">'
+      + `<b>${esc(a.name)}</b>${extra.length ? ' · ' + esc(extra.join(' · ')) : ''}`
+      + '</div></div>');
+    return out.join('');
+  }
+
+  function subtitle(a) {
+    return [a.ecu || a.node, a.code].filter(Boolean).join(' · ');
+  }
+
+  // ---- element builders -----------------------------------------------------
+
+  function faultCard(a, onOpen) {
+    const el = document.createElement('button');
+    el.type = 'button';
+    el.className = 'fault' + (a.hardware ? ' hw' : '');
+    el.title = tooltip(a);
+    el.innerHTML = `<span class="tag">${esc(a.ecu || '')}${a.code ? ' · ' + esc(a.code) : ''}`
+      + `${a.hardware ? ' · hw' : ''}</span>`
+      + `<div class="f-title">${esc(a.title)}</div>`
+      + (a.description ? `<div class="f-desc">${esc(a.description)}</div>` : '');
+    el.onclick = () => onOpen(a);
+    return el;
+  }
+
+  function logRow(e, onOpen) {
+    const el = document.createElement('button');
+    el.type = 'button';
+    el.className = 'alog-row';
+    el.title = tooltip(e);
+    el.innerHTML = `<span class="t">${esc(fmtTime(e.last))}</span>`
+      + `<span class="ecu">${esc(e.ecu || '')}</span>`
+      + `<span class="code">${esc(e.code || 'a' + e.alert_code)}</span>`
+      + `<span class="ttl">${esc(e.title)}</span>`
+      + `<span class="why">${esc(logWhy(e))}</span>`
+      + `<span class="n">×${esc(e.count)}</span>`;
+    el.onclick = () => onOpen(e);
+    return el;
+  }
+
+  // ---- page wiring ----------------------------------------------------------
+
+  /* Wire a modal (a .modal wrapper + title/body elements) and return open(a). */
+  function mountModal(modalEl, titleEl, bodyEl, closeEl) {
+    const close = () => modalEl.classList.remove('open');
+    if (closeEl) closeEl.onclick = close;
+    modalEl.onclick = ev => { if (ev.target === modalEl) close(); };
+    document.addEventListener('keydown', ev => {
+      if (ev.key === 'Escape' && modalEl.classList.contains('open')) close();
+    });
+    return function open(a) {
+      titleEl.textContent = a.title || a.name;
+      bodyEl.innerHTML = `<div class="a-sub">${esc(subtitle(a))}</div>` + detailHtml(a);
+      modalEl.classList.add('open');
+    };
+  }
+
+  /* Repaint a faults container. Returns the number rendered. */
+  function renderFaults(box, faults, onOpen, emptyHtml) {
+    box.innerHTML = '';
+    if (!faults || !faults.length) {
+      box.innerHTML = emptyHtml || '<div class="no-faults">No active faults</div>';
+      return 0;
+    }
+    faults.forEach(f => box.appendChild(faultCard(f, onOpen)));
+    return faults.length;
+  }
+
+  /* Repaint an alert-log container. Returns the number rendered. */
+  function renderLog(box, entries, onOpen, emptyHtml) {
+    box.innerHTML = '';
+    if (!entries || !entries.length) {
+      box.innerHTML = emptyHtml
+        || '<div class="hint">Nothing logged yet — ECUs broadcast an empty alert log '
+           + 'until something is wrong.</div>';
+      return 0;
+    }
+    entries.forEach(e => box.appendChild(logRow(e, onOpen)));
+    return entries.length;
+  }
+
+  window.TMAlerts = {
+    esc, hex3, bytes, fmtTime, logWhy, tooltip, detailHtml, subtitle,
+    faultCard, logRow, mountModal, renderFaults, renderLog,
+  };
+})();

--- a/can_live_ui/dash.html
+++ b/can_live_ui/dash.html
@@ -1,0 +1,466 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>TM3 Drive HUD</title>
+<style>
+  /* Design system matched to the CAN Live Viewer (index.html) */
+  :root{
+    --bg:#0f0f11; --panel:#18181c; --panel2:#1e1e24; --border:#2a2a32;
+    --accent:#e31937; --accent-dim:#8a0f20; --text:#e8e8ec; --dim:#7a7a88;
+    --ok:#22c55e; --warn:#f59e0b; --info:#22c55e; --danger:#e31937; --flash:#3a3a10;
+  }
+  *,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
+  body{background:var(--bg);color:var(--text);
+    font-family:'SF Mono','Cascadia Code','Fira Mono',monospace;font-size:13px;line-height:1.4}
+  a{color:var(--accent);text-decoration:none}
+  .wrap{max-width:1000px;margin:0 auto;padding:18px}
+  header{display:flex;align-items:center;gap:12px;padding:12px 2px 16px;
+    border-bottom:1px solid var(--border);margin-bottom:16px}
+  header h1{font-size:15px;font-weight:700;color:var(--accent);letter-spacing:.02em}
+  header .spacer{flex:1}
+  #conn{display:flex;align-items:center;gap:6px;color:var(--dim);font-size:11px;
+    text-transform:uppercase;letter-spacing:.06em}
+  .dot{width:8px;height:8px;border-radius:50%;background:#444;flex-shrink:0}
+  .dot.live{background:var(--ok)}
+  .btn{background:none;color:var(--dim);border:1px solid var(--border);border-radius:4px;
+    padding:5px 11px;cursor:pointer;font:inherit;font-size:11px;text-transform:uppercase;
+    letter-spacing:.05em;white-space:nowrap;transition:background .1s,color .1s,border-color .1s}
+  .btn:hover{color:var(--text);border-color:var(--accent-dim)}
+  .banner{background:var(--flash);border:1px solid var(--accent-dim);color:#e6c98a;border-radius:4px;
+    padding:9px 12px;margin-bottom:16px;font-size:12px}
+  .panel{background:var(--panel);border:1px solid var(--border);border-radius:6px;padding:16px}
+  .grid{display:grid;gap:14px}
+  .top{grid-template-columns:1.1fr 1fr}
+  @media(max-width:720px){.top{grid-template-columns:1fr}}
+  .label{color:var(--dim);font-size:10px;text-transform:uppercase;letter-spacing:.09em;margin-bottom:6px}
+
+  /* immobilizer + system state strip */
+  .status-strip{display:flex;gap:14px;margin-bottom:14px;flex-wrap:wrap}
+  .status-card{flex:1;min-width:160px;background:var(--panel);border:1px solid var(--border);
+    border-radius:6px;padding:12px 14px}
+  .status-val{font-size:19px;font-weight:700;margin-top:3px;letter-spacing:.02em}
+  .status-card.ok{border-color:var(--ok)} .status-card.ok .status-val{color:var(--ok)}
+  .status-card.warn{border-color:var(--warn)} .status-card.warn .status-val{color:var(--warn)}
+  .status-card.danger{border-color:var(--accent)} .status-card.danger .status-val{color:var(--accent)}
+
+  /* speed */
+  .speed{display:flex;flex-direction:column;align-items:center;justify-content:center}
+  .speed .num{font-size:82px;font-weight:700;line-height:1;font-variant-numeric:tabular-nums;color:var(--text)}
+  .speed .unit{color:var(--dim);font-size:12px;letter-spacing:.2em;margin-top:6px}
+  .accel{margin-top:14px;width:100%}
+  .bar{height:8px;background:var(--bg);border:1px solid var(--border);border-radius:3px;overflow:hidden}
+  .bar>span{display:block;height:100%;width:0;background:var(--accent);transition:width .12s}
+
+  /* gear */
+  .gears{display:grid;grid-template-columns:repeat(4,1fr);gap:10px;margin-top:6px}
+  .gear{position:relative;background:var(--panel2);border:1px solid var(--border);border-radius:6px;
+    padding:16px 0;text-align:center;font-size:24px;font-weight:700;cursor:pointer;color:var(--dim);
+    transition:.1s}
+  .gear:hover{border-color:var(--accent-dim);color:var(--text)}
+  .gear.reported{color:#fff;background:var(--accent);border-color:var(--accent)}
+  .gear.commanded::after{content:"";position:absolute;inset:3px;border:1px dashed var(--accent);
+    border-radius:4px;opacity:.8}
+  .gear[disabled]{cursor:not-allowed;opacity:.45}
+  .gear-note{color:var(--dim);font-size:11px;margin-top:10px;text-align:center}
+
+  /* LV power */
+  .lv-btns{display:grid;grid-template-columns:repeat(4,1fr);gap:10px}
+  .lv-btn{background:var(--panel2);border:1px solid var(--border);border-radius:6px;padding:14px 6px;
+    text-align:center;font-size:11px;font-weight:600;text-transform:uppercase;letter-spacing:.05em;
+    color:var(--dim);cursor:pointer;transition:.1s}
+  .lv-btn:hover{border-color:var(--accent-dim);color:var(--text)}
+  .lv-btn.on{background:var(--accent);border-color:var(--accent);color:#fff}
+  .lv-btn[disabled]{cursor:not-allowed;opacity:.45}
+
+  /* telltales */
+  .tells{display:grid;grid-template-columns:repeat(auto-fill,minmax(120px,1fr));gap:8px}
+  .tell{border:1px solid var(--border);border-radius:4px;padding:9px 10px;background:var(--panel2);
+    font-size:11px;font-weight:600;letter-spacing:.05em;text-transform:uppercase;color:var(--dim);
+    text-align:center;opacity:.5}
+  .tell.lit{opacity:1}
+  .tell.lit.danger{background:rgba(227,25,55,.15);border-color:var(--accent);color:#f2909c}
+  .tell.lit.warn{background:rgba(245,158,11,.15);border-color:var(--warn);color:var(--warn)}
+  .tell.lit.info{background:rgba(34,197,94,.15);border-color:var(--info);color:var(--info)}
+
+  /* faults */
+  .faults-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(250px,1fr));gap:8px}
+  .fault{display:block;width:100%;text-align:left;font:inherit;cursor:pointer;
+    border:1px solid var(--accent);border-radius:4px;padding:8px 10px;font-size:11px;
+    background:rgba(227,25,55,.1);color:#f2909c;overflow:hidden;transition:.1s}
+  .fault:hover{background:rgba(227,25,55,.2)}
+  .fault.hw{border-color:var(--border);background:var(--panel2);color:var(--dim)}
+  .fault.hw:hover{background:#26262e}
+  .fault .tag{float:right;font-size:9px;text-transform:uppercase;letter-spacing:.05em;opacity:.7;
+    margin-left:6px}
+  .fault .f-title{font-size:12px;font-weight:600}
+  .fault .f-desc{margin-top:3px;opacity:.75;line-height:1.35;
+    display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical;overflow:hidden}
+  .no-faults{color:var(--ok);font-size:12px}
+
+  /* alert log */
+  .alog{display:flex;flex-direction:column;gap:4px}
+  .alog-row{display:flex;align-items:baseline;gap:10px;width:100%;text-align:left;font:inherit;
+    font-size:11px;cursor:pointer;background:var(--panel2);border:1px solid var(--border);
+    border-radius:4px;padding:7px 10px;color:var(--text);transition:.1s}
+  .alog-row:hover{border-color:var(--accent-dim)}
+  .alog-row .t{color:var(--dim);font-variant-numeric:tabular-nums;flex-shrink:0}
+  .alog-row .ecu{color:var(--accent);font-weight:700;flex-shrink:0}
+  .alog-row .code{color:var(--dim);flex-shrink:0}
+  .alog-row .ttl{font-weight:600;flex-shrink:0}
+  .alog-row .why{color:var(--warn);overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+  .alog-row .n{margin-left:auto;color:var(--dim);flex-shrink:0}
+  .hint{color:var(--dim);font-size:11px;line-height:1.5}
+
+  /* alert detail sheet */
+  .a-sub{color:var(--dim);font-size:11px;margin:2px 0 14px;letter-spacing:.04em}
+  .a-sec{margin-bottom:12px}
+  .a-sec h3{font-size:10px;text-transform:uppercase;letter-spacing:.09em;color:var(--dim);
+    margin-bottom:4px;font-weight:600}
+  .a-sec p{font-size:12px;line-height:1.55}
+  .a-code{background:var(--panel2);border:1px solid var(--border);border-radius:4px;
+    padding:8px 10px;font-size:11px;color:var(--dim);word-break:break-all}
+  .a-code b{color:var(--text);font-weight:600}
+  .a-kv{display:grid;grid-template-columns:auto 1fr;gap:3px 12px;font-size:11px}
+  .a-kv dt{color:var(--dim)}
+
+  /* settings */
+  .settings{display:grid;grid-template-columns:repeat(auto-fill,minmax(200px,1fr));gap:12px}
+  .field{display:flex;flex-direction:column;gap:5px}
+  .field span{color:var(--dim);font-size:11px;text-transform:uppercase;letter-spacing:.04em}
+  select,input[type=number]{background:var(--bg);color:var(--text);border:1px solid var(--border);
+    border-radius:4px;padding:6px 8px;font:inherit;font-size:12px}
+  select:focus,input:focus{outline:none;border-color:var(--accent-dim)}
+  h2{font-size:11px;text-transform:uppercase;letter-spacing:.09em;color:var(--dim);
+    margin:0 0 12px;padding-bottom:8px;border-bottom:1px solid var(--border)}
+  .mt{margin-top:14px}
+
+  /* modal */
+  .modal{position:fixed;inset:0;background:rgba(0,0,0,.72);display:none;z-index:20;
+    align-items:flex-start;justify-content:center;padding:24px;overflow:auto}
+  .modal.open{display:flex}
+  .modal .sheet{background:var(--panel);border:1px solid var(--border);border-radius:6px;
+    width:100%;max-width:840px;padding:20px}
+  .modal header{margin-bottom:8px;border:none;padding:0}
+  .modal header h1{color:var(--accent)}
+  details{border:1px solid var(--border);border-radius:4px;margin-bottom:10px;background:var(--panel2)}
+  details>summary{cursor:pointer;padding:10px 14px;font-weight:600;font-size:11px;text-transform:uppercase;
+    letter-spacing:.06em;color:var(--dim);list-style:none}
+  details>summary::-webkit-details-marker{display:none}
+  details[open]>summary{border-bottom:1px solid var(--border);color:var(--text)}
+  .cfg-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(240px,1fr));gap:12px;padding:14px}
+  #toast{position:fixed;bottom:18px;left:50%;transform:translateX(-50%);background:var(--panel);
+    border:1px solid var(--border);border-radius:4px;padding:9px 14px;font-size:12px;opacity:0;
+    transition:.2s;pointer-events:none;z-index:30}
+  #toast.show{opacity:1}
+  #toast.err{border-color:var(--accent);color:var(--accent)}
+</style>
+</head>
+<body>
+<div class="wrap">
+  <header>
+    <h1>TM3 · Drive HUD</h1>
+    <span id="conn"><span class="dot"></span><span id="conn-txt">connecting…</span></span>
+    <span class="spacer"></span>
+    <button class="btn" id="cfg-open">Car config</button>
+    <a class="btn" href="/">CAN viewer →</a>
+  </header>
+
+  <div id="banner" class="banner" style="display:none"></div>
+
+  <div class="status-strip">
+    <div class="status-card" id="immo-card">
+      <div class="label">Immobilizer</div>
+      <div class="status-val" id="immo">—</div>
+    </div>
+    <div class="status-card" id="sys-card">
+      <div class="label">System state</div>
+      <div class="status-val" id="sysstate">—</div>
+    </div>
+  </div>
+
+  <div class="grid top">
+    <div class="panel speed">
+      <div class="num" id="speed">—</div>
+      <div class="unit">KM/H</div>
+      <div class="accel">
+        <div class="label">Accelerator <span id="accel-val"></span></div>
+        <div class="bar"><span id="accel-bar"></span></div>
+      </div>
+    </div>
+
+    <div class="panel">
+      <h2>Gear</h2>
+      <div class="gears" id="gears"></div>
+      <div class="gear-note" id="gear-note"></div>
+    </div>
+  </div>
+
+  <div class="panel mt">
+    <h2>LV power <span id="lv-cur" style="color:var(--dim);font-weight:400"></span></h2>
+    <div class="lv-btns" id="lv-btns"></div>
+  </div>
+
+  <div class="panel mt">
+    <h2>Telltales</h2>
+    <div class="tells" id="tells"></div>
+  </div>
+
+  <div class="panel mt">
+    <h2>Faults <span id="fault-count" style="color:var(--dim);font-weight:400"></span></h2>
+    <div class="faults-grid" id="faults"></div>
+  </div>
+
+  <div class="panel mt">
+    <h2>Alert log <span id="alog-count" style="color:var(--dim);font-weight:400"></span>
+      <button class="btn" id="alog-clear" style="float:right;margin-top:-4px">Clear</button></h2>
+    <div class="alog" id="alog"></div>
+  </div>
+
+  <div class="panel mt">
+    <h2>Drive settings</h2>
+    <div class="settings" id="settings"></div>
+  </div>
+</div>
+
+<!-- Car-config modal -->
+<div class="modal" id="cfg-modal">
+  <div class="sheet">
+    <header>
+      <h1 id="cfg-title">Car config — GTW_carConfig</h1>
+      <span class="spacer"></span>
+      <button class="btn" id="cfg-close">Close</button>
+    </header>
+    <p style="color:var(--dim);font-size:12px;margin:.2em 0 14px">
+      Every field is transmitted as a named signal via the DB encoder. Changes apply on the next
+      broadcast of that mux page.</p>
+    <div id="cfg-body"></div>
+  </div>
+</div>
+
+<!-- Alert detail modal -->
+<div class="modal" id="alert-modal">
+  <div class="sheet">
+    <header>
+      <h1 id="alert-title">Alert</h1>
+      <span class="spacer"></span>
+      <button class="btn" id="alert-close">Close</button>
+    </header>
+    <div id="alert-body"></div>
+  </div>
+</div>
+
+<div id="toast"></div>
+
+<script src="/alerts.js"></script>
+<script>
+const GEARS = ["P","R","N","D"];
+let controlOn = false, uiBuilt = false, cfgLoaded = false, lvBuilt = false;
+
+const $ = s => document.querySelector(s);
+function toast(msg, err){
+  const t = $("#toast"); t.textContent = msg; t.className = "show" + (err ? " err" : "");
+  clearTimeout(t._t); t._t = setTimeout(() => t.className = "", 1800);
+}
+async function post(url, body){
+  try{
+    const r = await fetch(url, {method:"POST", headers:{"Content-Type":"application/json"},
+      body: JSON.stringify(body)});
+    const j = await r.json().catch(() => ({}));
+    if(!r.ok){ toast(j.error || ("HTTP " + r.status), true); return null; }
+    return j;
+  }catch(e){ toast(String(e), true); return null; }
+}
+
+// Alert detail sheet, shared by the fault cards and the alert-log rows.
+const openAlert = TMAlerts.mountModal(
+  $("#alert-modal"), $("#alert-title"), $("#alert-body"), $("#alert-close"));
+
+// ---- gear buttons ----
+const gearsEl = $("#gears");
+GEARS.forEach(g => {
+  const b = document.createElement("button");
+  b.className = "gear"; b.textContent = g; b.dataset.g = g;
+  b.onclick = () => post("/api/gear", {value: g}).then(r => r && toast("Gear → " + g));
+  gearsEl.appendChild(b);
+});
+
+// ---- drive settings (built once from ui_schema) ----
+function buildSettings(schema, values){
+  const box = $("#settings"); box.innerHTML = "";
+  Object.entries(schema).forEach(([field, spec]) => {
+    const wrap = document.createElement("label"); wrap.className = "field";
+    const name = document.createElement("span"); name.textContent = spec.label;
+    const sel = document.createElement("select"); sel.dataset.field = field;
+    Object.entries(spec.options).forEach(([label, val]) => {
+      const o = document.createElement("option"); o.value = val; o.textContent = label; sel.appendChild(o);
+    });
+    if(values && field in values) sel.value = values[field];
+    sel.disabled = !controlOn;
+    sel.onchange = () => post("/api/ui", {field, value: Number(sel.value)})
+      .then(r => r && toast(spec.label + " set"));
+    wrap.append(name, sel); box.appendChild(wrap);
+  });
+  uiBuilt = true;
+}
+
+// ---- render loop ----
+function setConn(live){
+  $("#conn .dot").classList.toggle("live", live);
+  $("#conn-txt").textContent = live ? "receiving" : "no data";
+}
+function render(s){
+  // banner
+  const banner = $("#banner");
+  if(!s.control){
+    banner.style.display = "";
+    banner.textContent = "Read-only — start can_live with --control to drive gear / settings. " +
+      "Run vehicle_sim --no-shifter --exclude 334 alongside for immobilizer + liveness.";
+  } else banner.style.display = "none";
+
+  // immobilizer + system state
+  const immo = $("#immo"); immo.textContent = s.immobilizer ?? "—";
+  const ic = $("#immo-card"); ic.className = "status-card " +
+    (s.immobilizer == null ? "" : s.immobilizer_ok ? "ok" : "warn");
+  $("#sysstate").textContent = s.system_state ?? "—";
+
+  // speed + accel
+  $("#speed").textContent = s.speed_kph == null ? "—" : Math.round(s.speed_kph);
+  const ap = s.accel_pct;
+  $("#accel-val").textContent = ap == null ? "" : ap.toFixed(0) + "%";
+  $("#accel-bar").style.width = (ap == null ? 0 : Math.max(0, Math.min(100, ap))) + "%";
+
+  // gears
+  gearsEl.querySelectorAll(".gear").forEach(b => {
+    b.classList.toggle("reported", b.dataset.g === s.gear);
+    b.classList.toggle("commanded", b.dataset.g === s.commanded_gear);
+    b.disabled = !s.control;
+  });
+  $("#gear-note").textContent = s.gear
+    ? ("Reported gear: " + s.gear + (s.commanded_gear ? "  ·  commanded: " + s.commanded_gear : ""))
+    : "No DI_gear on the bus yet — is the DU powered + on the bus?";
+
+  // LV power buttons (built once from lv_options)
+  if(s.lv_options && !lvBuilt){
+    const box = $("#lv-btns"); box.innerHTML = "";
+    s.lv_options.forEach(st => {
+      const b = document.createElement("button");
+      b.className = "lv-btn"; b.dataset.st = st; b.textContent = st;
+      b.onclick = () => post("/api/lv", {value: st}).then(r => r && toast("LV power → " + st));
+      box.appendChild(b);
+    });
+    lvBuilt = true;
+  }
+  $("#lv-cur").textContent = s.lv_state ? "· " + s.lv_state : "";
+  $("#lv-btns").querySelectorAll(".lv-btn").forEach(b => {
+    b.classList.toggle("on", b.dataset.st === s.lv_state);
+    b.disabled = !s.control;
+  });
+
+  // telltales
+  const tells = $("#tells");
+  tells.innerHTML = "";
+  (s.telltales || []).forEach(t => {
+    const el = document.createElement("div");
+    el.className = "tell " + (t.lit ? "lit " + (t.level || "") : "");
+    el.textContent = t.label; tells.appendChild(el);
+  });
+
+  // faults (active alert-matrix bits; hardware faults dimmed + tagged). Each card
+  // carries Tesla's own description; click opens the full cause/clear/effect.
+  const fs = s.faults || [];
+  $("#fault-count").textContent = fs.length ? "(" + fs.length + ")" : "";
+  TMAlerts.renderFaults($("#faults"), fs, openAlert);
+
+  // settings (build once)
+  controlOn = !!s.control;
+  if(s.ui_schema && (!uiBuilt || !s.ui)) buildSettings(s.ui_schema, s.ui);
+  else if(s.ui){
+    Object.entries(s.ui).forEach(([f, v]) => {
+      const sel = $(`select[data-field="${f}"]`);
+      if(sel && document.activeElement !== sel) sel.value = v;
+    });
+  }
+}
+
+let missed = 0;
+async function poll(){
+  try{
+    const r = await fetch("/api/dash");
+    const s = await r.json();
+    setConn(s.connected); missed = 0;
+    render(s);
+  }catch(e){
+    if(++missed > 3) setConn(false);
+  }
+}
+setInterval(poll, 200); poll();
+
+// ---- alert log (what the ECUs logged about their alerts) ----
+// Polled slower than the HUD: the log only changes when an ECU raises or
+// re-raises something, and the payload carries every distinct entry.
+let catalogWarned = false;
+async function pollAlerts(){
+  let a;
+  try{ a = await (await fetch("/api/alerts")).json(); }catch(e){ return; }
+  const n = TMAlerts.renderLog($("#alog"), a.log, openAlert);
+  $("#alog-count").textContent = n ? "(" + n + ")" : "";
+  if(!a.catalog && !catalogWarned){
+    catalogWarned = true;
+    $("#alog").insertAdjacentHTML("afterbegin",
+      '<div class="hint">No firmware alert catalog loaded — alerts show their name '
+      + 'only. Set TM3_ROOT to a firmware extraction for Tesla’s descriptions.</div>');
+  }
+}
+setInterval(pollAlerts, 1000); pollAlerts();
+
+$("#alog-clear").onclick = () => post("/api/alerts/clear", {})
+  .then(r => { if(r){ toast("Alert log cleared"); pollAlerts(); } });
+
+// ---- car config modal ----
+const modal = $("#cfg-modal");
+$("#cfg-open").onclick = async () => { modal.classList.add("open"); if(!cfgLoaded) await loadConfig(); };
+$("#cfg-close").onclick = () => modal.classList.remove("open");
+modal.onclick = e => { if(e.target === modal) modal.classList.remove("open"); };
+
+async function loadConfig(){
+  const body = $("#cfg-body");
+  let sch;
+  try{ sch = await (await fetch("/api/carconfig")).json(); }
+  catch(e){ body.textContent = "Failed to load config."; return; }
+  if(sch.error){ body.innerHTML = '<div class="banner" style="display:block">' + sch.error + '</div>'; return; }
+  $("#cfg-title").textContent = "Car config — " + sch.msg;
+  body.innerHTML = "";
+  sch.pages.forEach((pg, i) => {
+    const d = document.createElement("details"); if(i === 0) d.open = true;
+    const sum = document.createElement("summary");
+    sum.textContent = `Page ${pg.page} · ${pg.signals.length} signals`;
+    const grid = document.createElement("div"); grid.className = "cfg-grid";
+    pg.signals.forEach(sig => grid.appendChild(cfgField(sig)));
+    d.append(sum, grid); body.appendChild(d);
+  });
+  cfgLoaded = true;
+}
+function cfgField(sig){
+  const wrap = document.createElement("label"); wrap.className = "field";
+  const name = document.createElement("span"); name.textContent = sig.name.replace(/^GTW_/, "");
+  let input;
+  if(sig.options){
+    input = document.createElement("select");
+    Object.entries(sig.options).forEach(([label, val]) => {
+      const o = document.createElement("option"); o.value = val;
+      o.textContent = `${label} (${val})`; input.appendChild(o);
+    });
+    input.value = sig.value;
+  }else{
+    input = document.createElement("input"); input.type = "number";
+    input.min = 0; input.max = (2 ** sig.width) - 1; input.value = sig.value;
+  }
+  input.onchange = () => post("/api/carconfig", {signal: sig.name, value: Number(input.value)})
+    .then(r => r && toast(sig.name.replace(/^GTW_/, "") + " set"));
+  wrap.append(name, input); return wrap;
+}
+</script>
+</body>
+</html>

--- a/can_live_ui/index.html
+++ b/can_live_ui/index.html
@@ -17,6 +17,7 @@
     --text-dim: #7a7a88;
     --green: #22c55e;
     --yellow: #f59e0b;
+    --red: #ef4444;
     --flash: #3a3a10;
   }
 
@@ -53,6 +54,19 @@
     transition: color .1s, border-color .1s;
   }
   .tab-btn:hover { color: var(--text); }
+  /* active-fault count on the Alerts tab, so a fault is visible from any tab */
+  #tab-alert-badge {
+    display: none;
+    margin-left: 7px;
+    padding: 1px 6px;
+    border-radius: 8px;
+    background: var(--accent);
+    color: #fff;
+    font-size: 10px;
+    font-weight: 700;
+    letter-spacing: 0;
+    vertical-align: 1px;
+  }
   .tab-btn.active {
     color: var(--accent);
     border-bottom-color: var(--accent);
@@ -204,7 +218,7 @@
     text-align: right;
   }
 
-  #alert-filter-btn {
+  #alert-filter-btn, #tx-filter-btn, .plain-btn {
     background: none;
     border: 1px solid var(--border);
     border-radius: 4px;
@@ -216,8 +230,10 @@
     white-space: nowrap;
     transition: background .1s, color .1s, border-color .1s;
   }
-  #alert-filter-btn:hover { color: var(--text); border-color: var(--accent-dim); }
-  #alert-filter-btn.active {
+  #alert-filter-btn:hover, #tx-filter-btn:hover, .plain-btn:hover {
+    color: var(--text); border-color: var(--accent-dim);
+  }
+  #alert-filter-btn.active, #tx-filter-btn.active {
     background: rgba(227,25,55,.15);
     border-color: var(--accent);
     color: var(--accent);
@@ -591,6 +607,341 @@
     flex-direction: column;
     overflow: hidden;
   }
+
+  /* ===================================================================
+     ODIN + DID tabs (folded in from the old standalone odin.html).
+     Scoped to .odin: these override index's .sidebar/.sidebar-header/
+     .placeholder and add bare-element rules that must not escape into the
+     Live/Explorer/Raw tabs -- odin styles `input[type=text]` and
+     `table.grid`, and index styles bare `table`/`td`. Rules index already
+     provides identically (:root, body, .tab-btn, .tab-view, .main) are gone.
+     =================================================================== */
+  .odin .sidebar { width: 300px; min-width: 220px; }
+  .odin .sidebar-header {
+    padding: 12px;
+    display: flex;
+    gap: 8px;
+    align-items: center;
+    font-size: inherit;
+    text-transform: none;
+    letter-spacing: normal;
+    color: var(--text);
+  }
+  .odin input[type=text], .odin input[type=search] {
+    flex: 1;
+    background: var(--bg);
+    border: 1px solid var(--border);
+    color: var(--text);
+    font: inherit;
+    font-size: 12px;
+    padding: 6px 8px;
+    border-radius: 3px;
+    outline: none;
+  }
+  .odin input:focus { border-color: var(--accent-dim); }
+
+  .odin .list { overflow-y: auto; flex: 1; }
+  .odin .list-item {
+    display: block;
+    width: 100%;
+    text-align: left;
+    padding: 8px 12px;
+    background: none;
+    border: none;
+    border-left: 3px solid transparent;
+    color: var(--text);
+    cursor: pointer;
+    font: inherit;
+    transition: background .1s, border-color .1s;
+    border-bottom: 1px solid rgba(255,255,255,.03);
+  }
+  .odin .list-item:hover { background: rgba(255,255,255,.04); }
+  .odin .list-item.active {
+    background: rgba(227,25,55,.1);
+    border-left-color: var(--accent);
+    color: #fff;
+  }
+  .odin .list-item .li-title { font-size: 12px; }
+  .odin .list-item .li-sub { font-size: 10px; color: var(--text-dim); margin-top: 2px; }
+  .odin .li-tag {
+    font-size: 9px; text-transform: uppercase; letter-spacing: .05em;
+    color: var(--yellow); border: 1px solid var(--border); border-radius: 3px;
+    padding: 1px 4px; margin-left: 6px;
+  }
+
+  .odin .pane-header {
+    padding: 14px 18px;
+    border-bottom: 1px solid var(--border);
+    flex-shrink: 0;
+  }
+  .odin .pane-header-row {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 12px;
+  }
+  .odin .pane-header h2 { font-size: 15px; font-weight: 700; }
+  .odin .pane-header .sub { color: var(--text-dim); font-size: 11px; margin-top: 4px; }
+  .odin .pane-body { flex: 1; overflow-y: auto; padding: 18px; }
+  .odin .placeholder {
+    display: block;
+    height: auto;
+    color: var(--text-dim);
+    padding: 40px 18px;
+    text-align: center;
+  }
+
+  #odin-conn { font-size: 11px; color: var(--text-dim); white-space: nowrap; }
+  #odin-conn .dot { color: var(--red); }
+  #odin-conn.up .dot { color: var(--green); }
+
+  .odin button.btn {
+    background: var(--accent);
+    color: #fff;
+    border: none;
+    font: inherit;
+    font-size: 12px;
+    text-transform: uppercase;
+    letter-spacing: .06em;
+    padding: 8px 18px;
+    border-radius: 3px;
+    cursor: pointer;
+    transition: background .1s;
+  }
+  .odin button.btn:hover { background: #ff2444; }
+  .odin button.btn:disabled { background: var(--accent-dim); cursor: not-allowed; opacity: .6; }
+  .odin button.btn.ghost { background: none; border: 1px solid var(--border); color: var(--text); }
+  .odin button.btn.ghost:hover { border-color: var(--accent-dim); background: rgba(255,255,255,.03); }
+
+  .odin .badge {
+    display: inline-block; padding: 2px 8px; border-radius: 3px;
+    font-size: 11px; font-weight: 700; text-transform: uppercase; letter-spacing: .05em;
+  }
+  .odin .badge.pass { background: rgba(34,197,94,.15); color: var(--green); }
+  .odin .badge.fail { background: rgba(239,68,68,.15); color: var(--red); }
+
+  .odin .row { display: flex; gap: 8px; align-items: center; flex-wrap: wrap; margin-bottom: 14px; }
+  .odin .kv { margin-bottom: 6px; }
+  .odin .kv .k { color: var(--text-dim); display: inline-block; min-width: 130px; }
+
+  .odin .log {
+    background: #0b0b0d;
+    border: 1px solid var(--border);
+    border-radius: 3px;
+    padding: 10px;
+    font-size: 11px;
+    line-height: 1.5;
+    height: 240px;
+    overflow-y: auto;
+    white-space: pre-wrap;
+    margin-top: 12px;
+  }
+  .odin .log .ev-metric { color: var(--yellow); }
+  .odin .log .ev-trace { color: var(--text-dim); }
+  .odin .log .ev-done { color: var(--green); }
+  .odin .log .ev-error { color: var(--red); }
+
+  .odin table.grid { width: 100%; border-collapse: collapse; margin-top: 8px; }
+  .odin table.grid th, .odin table.grid td {
+    text-align: left; padding: 6px 10px; border-bottom: 1px solid var(--border);
+    font-size: 12px;
+  }
+  .odin table.grid th {
+    color: var(--text-dim); font-weight: 400; font-size: 10px;
+    text-transform: uppercase; letter-spacing: .05em;
+  }
+
+  .odin .field-row { display: flex; gap: 8px; align-items: center; margin-bottom: 8px; }
+  .odin .field-row label { min-width: 160px; color: var(--text-dim); font-size: 12px; }
+  .odin .field-row input { max-width: 200px; }
+  .odin .err { color: var(--red); font-size: 12px; margin-top: 10px; }
+  .odin .section-label {
+    font-size: 10px; text-transform: uppercase; letter-spacing: .08em;
+    color: var(--text-dim); padding: 8px 12px 4px; border-top: 1px solid var(--border);
+  }
+
+  /* "Requires on bus" (per-proc static requirements + live seen/missing dots) */
+  .odin .reqs { margin-top: 16px; border-top: 1px solid var(--border); padding-top: 12px; }
+  .odin .reqs h3 {
+    font-size: 11px; text-transform: uppercase; letter-spacing: .06em;
+    color: var(--text-dim); margin-bottom: 8px;
+  }
+  .odin .bus-group { margin-bottom: 10px; }
+  .odin .bus-name {
+    font-size: 10px; text-transform: uppercase; letter-spacing: .05em;
+    color: var(--accent); margin-bottom: 4px;
+  }
+  .odin .sig-row { display: flex; gap: 8px; align-items: center; padding: 2px 0; font-size: 12px; }
+  .odin .sig-dot { font-size: 9px; color: var(--text-dim); }
+  .odin .sig-row.seen .sig-dot { color: var(--green); }
+  .odin .sig-row.missing .sig-dot { color: var(--red); }
+  .odin .sig-kind {
+    font-size: 9px; text-transform: uppercase; letter-spacing: .05em; color: var(--text-dim);
+    border: 1px solid var(--border); border-radius: 3px; padding: 0 4px;
+  }
+  .odin .reqs .note { font-size: 11px; color: var(--yellow); margin-top: 6px; }
+  .odin .reqs .muted { font-size: 11px; color: var(--text-dim); }
+  .odin .muted { font-size: 11px; color: var(--text-dim); }
+
+  /* low-level UDS operations */
+  .odin select {
+    background: var(--bg);
+    border: 1px solid var(--border);
+    color: var(--text);
+    font: inherit;
+    font-size: 12px;
+    padding: 6px 8px;
+    border-radius: 3px;
+    outline: none;
+    max-width: 200px;
+  }
+  .odin select:focus { border-color: var(--accent-dim); }
+  .odin input[type=checkbox] { accent-color: var(--accent); width: 14px; height: 14px; }
+  .odin .uds-op {
+    border: 1px solid var(--border);
+    border-radius: 3px;
+    padding: 12px 14px;
+    margin-bottom: 10px;
+  }
+  .odin .uds-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(290px, 1fr));
+    gap: 10px;
+    /* stretch (the default), not start: help text runs one to three lines, so
+       self-sized cards leave a ragged row. Equal heights + the Run button pinned
+       to the bottom of each card gives the row one baseline to read along. */
+    align-items: stretch;
+  }
+  .odin .uds-grid { margin-bottom: 18px; }
+  .odin .uds-grid .uds-op {
+    margin-bottom: 0;
+    display: flex;
+    flex-direction: column;
+  }
+  .odin .uds-grid .uds-op .row { margin-top: auto; padding-top: 4px; }
+  /* Inside a column the 160px label gutter no longer fits; let the label take
+     the slack and cap the control instead. */
+  .odin .uds-grid .field-row label { min-width: 0; flex: 1; }
+  .odin .uds-grid .field-row input[type=text],
+  .odin .uds-grid select { max-width: 110px; }
+  /* the DID sidebar picker fills its row, like the text box it replaced */
+  .odin .sidebar-header select { flex: 1; max-width: none; }
+  .odin .field-row input.invalid,
+  .odin .field-row select.invalid { border-color: var(--red); }
+  /* the node picker carries "NAME  0x6xx/0x6xx", wider than the hex fields */
+  .odin .field-row select#uds-node { max-width: 240px; }
+  .odin .uds-node-err {
+    color: var(--red);
+    font-size: 11px;
+    min-height: 14px;
+    margin: -4px 0 8px 168px;   /* line up under the control, past the label gutter */
+  }
+  .odin .uds-section-head {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    width: 100%;
+    background: none;
+    border: none;
+    border-top: 1px solid var(--border);
+    font-family: inherit;
+    text-align: left;
+    cursor: pointer;
+    transition: color .1s;
+  }
+  .odin .uds-section-head:hover { color: var(--text); }
+  .odin .uds-caret {
+    display: inline-block;
+    font-size: 9px;
+    transition: transform .12s;
+  }
+  .odin .uds-section-head.collapsed .uds-caret { transform: rotate(-90deg); }
+  .odin .uds-section-count { margin-left: auto; opacity: .6; }
+  .odin .uds-grid.collapsed { display: none; }
+  .odin .uds-op-head { display: flex; align-items: center; gap: 8px; margin-bottom: 4px; }
+  .odin .uds-op-title { font-size: 12px; font-weight: 700; }
+  .odin .uds-help { font-size: 11px; color: var(--text-dim); margin-bottom: 10px; line-height: 1.45; }
+  .odin .uds-op .row { margin-bottom: 0; }
+
+  /* ---- alerts tab ----
+     The markup is generated by the shared renderer (/alerts.js, also used by
+     /dash); only these class definitions are per-page, bound to this palette. */
+  #alerts-scroll { flex: 1; overflow-y: auto; padding: 18px; }
+  .alerts-section { margin-bottom: 26px; }
+  .alerts-section h2 {
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: .09em;
+    color: var(--text-dim);
+    font-weight: 600;
+    margin-bottom: 10px;
+    padding-bottom: 8px;
+    border-bottom: 1px solid var(--border);
+  }
+  .alerts-section h2 .count { opacity: .7; font-weight: 400; }
+  .faults-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(260px, 1fr)); gap: 8px; }
+  .fault {
+    display: block; width: 100%; text-align: left; font: inherit; font-size: 11px;
+    cursor: pointer; border: 1px solid var(--accent); border-radius: 4px;
+    padding: 8px 10px; background: rgba(227,25,55,.1); color: #f2909c;
+    overflow: hidden; transition: background .1s;
+  }
+  .fault:hover { background: rgba(227,25,55,.2); }
+  /* bench hardware faults (no motor / HV / resolver wired) read as expected, not urgent */
+  .fault.hw { border-color: var(--border); background: var(--panel); color: var(--text-dim); }
+  .fault.hw:hover { background: #26262e; }
+  .fault .tag {
+    float: right; font-size: 9px; text-transform: uppercase;
+    letter-spacing: .05em; opacity: .7; margin-left: 6px;
+  }
+  .fault .f-title { font-size: 12px; font-weight: 600; }
+  .fault .f-desc {
+    margin-top: 3px; opacity: .75; line-height: 1.35;
+    display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden;
+  }
+  .no-faults { color: var(--green); font-size: 12px; }
+  .alog { display: flex; flex-direction: column; gap: 4px; }
+  .alog-row {
+    display: flex; align-items: baseline; gap: 10px; width: 100%; text-align: left;
+    font: inherit; font-size: 11px; cursor: pointer; background: var(--panel);
+    border: 1px solid var(--border); border-radius: 4px; padding: 7px 10px;
+    color: var(--text); transition: border-color .1s;
+  }
+  .alog-row:hover { border-color: var(--accent-dim); }
+  .alog-row .t { color: var(--text-dim); font-variant-numeric: tabular-nums; flex-shrink: 0; }
+  .alog-row .ecu { color: var(--accent); font-weight: 700; flex-shrink: 0; }
+  .alog-row .code { color: var(--text-dim); flex-shrink: 0; }
+  .alog-row .ttl { font-weight: 600; flex-shrink: 0; }
+  .alog-row .why { color: var(--yellow); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .alog-row .n { margin-left: auto; color: var(--text-dim); flex-shrink: 0; }
+  .hint { color: var(--text-dim); font-size: 11px; line-height: 1.5; }
+
+  /* alert detail modal (shared markup, see /alerts.js) */
+  .modal {
+    position: fixed; inset: 0; background: rgba(0,0,0,.72); display: none; z-index: 40;
+    align-items: flex-start; justify-content: center; padding: 24px; overflow: auto;
+  }
+  .modal.open { display: flex; }
+  .modal .sheet {
+    background: var(--panel); border: 1px solid var(--border); border-radius: 6px;
+    width: 100%; max-width: 760px; padding: 20px;
+  }
+  .modal .sheet-head { display: flex; align-items: center; gap: 12px; margin-bottom: 2px; }
+  .modal .sheet-head h1 { font-size: 16px; color: var(--accent); flex: 1; }
+  .a-sub { color: var(--text-dim); font-size: 11px; margin: 2px 0 14px; letter-spacing: .04em; }
+  .a-sec { margin-bottom: 12px; }
+  .a-sec h3 {
+    font-size: 10px; text-transform: uppercase; letter-spacing: .09em;
+    color: var(--text-dim); margin-bottom: 4px; font-weight: 600;
+  }
+  .a-sec p { font-size: 12px; line-height: 1.55; }
+  .a-code {
+    background: var(--bg); border: 1px solid var(--border); border-radius: 4px;
+    padding: 8px 10px; font-size: 11px; color: var(--text-dim); word-break: break-all;
+  }
+  .a-code b { color: var(--text); font-weight: 600; }
+  .a-kv { display: grid; grid-template-columns: auto 1fr; gap: 3px 12px; font-size: 11px; }
+  .a-kv dt { color: var(--text-dim); }
 </style>
 </head>
 <body>
@@ -598,8 +949,11 @@
 <!-- Tab bar -->
 <div id="tab-bar">
   <button class="tab-btn active" data-tab="live">Live</button>
+  <button class="tab-btn" data-tab="alerts">Alerts<span id="tab-alert-badge"></span></button>
   <button class="tab-btn" data-tab="explorer">DB Explorer</button>
   <button class="tab-btn" data-tab="raw">Raw Frames</button>
+  <button class="tab-btn" data-tab="odin">ODIN</button>
+  <button class="tab-btn" data-tab="did">DID</button>
 </div>
 
 <!-- ===================== LIVE TAB ===================== -->
@@ -616,6 +970,7 @@
     <div class="topbar">
       <input id="filter-input" class="filter-input" type="text" placeholder="Filter signals…">
       <button id="alert-filter-btn">Active alerts only</button>
+      <button id="tx-filter-btn" style="display:none">Hide our TX</button>
       <div id="fps-counter"></div>
       <div id="status-dot"></div>
       <div id="status-text">disconnected</div>
@@ -625,6 +980,38 @@
         <div>Choose an ECU node from the sidebar</div>
       </div>
     </div>
+  </div>
+</div>
+
+<!-- ===================== ALERTS TAB ===================== -->
+<div id="tab-alerts" class="tab-view">
+  <div class="main">
+    <div class="topbar">
+      <div id="alerts-status" style="color:var(--text-dim);font-size:12px">loading…</div>
+      <div style="flex:1"></div>
+      <button id="alerts-clear" class="plain-btn">Clear log</button>
+    </div>
+    <div id="alerts-scroll">
+      <div class="alerts-section">
+        <h2>Active faults <span class="count" id="al-fault-count"></span></h2>
+        <div class="faults-grid" id="al-faults"></div>
+      </div>
+      <div class="alerts-section">
+        <h2>Alert log <span class="count" id="al-log-count"></span></h2>
+        <div class="alog" id="al-log"></div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- Alert detail modal (shared renderer) -->
+<div class="modal" id="alert-modal">
+  <div class="sheet">
+    <div class="sheet-head">
+      <h1 id="alert-title">Alert</h1>
+      <button class="plain-btn" id="alert-close">Close</button>
+    </div>
+    <div id="alert-body"></div>
   </div>
 </div>
 
@@ -645,9 +1032,11 @@
       <input id="raw-id-filter" type="text" placeholder="Filter by ID (hex)…">
       <button id="raw-clear-btn" class="raw-btn">Clear</button>
       <button id="raw-freeze-btn" class="raw-btn">Freeze</button>
+      <button id="raw-tx-filter-btn" class="raw-btn" style="display:none">Hide our TX</button>
       <div id="raw-status">
         <div id="raw-status-dot"></div>
         <span id="raw-status-text">disconnected</span>
+        <span id="raw-rx-counter" style="margin-left:8px;color:var(--text-dim);font-size:11px"></span>
       </div>
     </div>
     <div id="raw-cards-wrap">
@@ -680,30 +1069,147 @@
   </div>
 </div>
 
+<!-- ===================== ODIN TAB ===================== -->
+<div id="tab-odin" class="tab-view odin">
+  <div class="sidebar">
+    <div class="sidebar-header">
+      <input type="search" id="proc-filter" placeholder="filter procedures…" autocomplete="off">
+    </div>
+    <div class="list" id="proc-list"><div class="placeholder">loading…</div></div>
+  </div>
+  <div class="main">
+    <div class="pane-header">
+      <div class="pane-header-row">
+        <div>
+          <h2 id="proc-title">Select a procedure</h2>
+          <div class="sub" id="proc-sub">runnable procedures from the ODIN bundle</div>
+        </div>
+        <div id="odin-conn"><span class="dot">●</span> <span id="odin-conn-txt">ws offline</span></div>
+      </div>
+    </div>
+    <div class="pane-body" id="odin-body">
+      <div class="placeholder">Pick a procedure on the left to run it against the bench.</div>
+    </div>
+  </div>
+</div>
+
+<!-- ===================== DID TAB ===================== -->
+<div id="tab-did" class="tab-view odin">
+  <div class="sidebar">
+    <div class="sidebar-header">
+      <select id="did-node"><option value="">node…</option></select>
+      <button class="btn ghost" id="did-load">Load</button>
+    </div>
+    <div class="list" id="did-list"><div class="placeholder">enter a node</div></div>
+  </div>
+  <div class="main">
+    <div class="pane-header">
+      <h2 id="did-title">Select a DID</h2>
+      <div class="sub" id="did-sub">read or write a data identifier</div>
+    </div>
+    <div class="pane-body" id="did-body">
+      <div class="placeholder">Load a node, then pick a DID to read or write.</div>
+    </div>
+  </div>
+</div>
+
+<script src="/alerts.js"></script>
 <script>
 const CONFIG = {
-  WS_URL:              `ws://${location.host}/ws`,
+  WS_URL:              '/ws',
   API_DB:              '/api/db',
   RECONNECT_MS:        1500,
   FPS_INTERVAL_MS:     1000,
   AGE_INTERVAL_MS:     250,
   FLASH_MS:            300,
   STALE_MULTIPLIER:    3,
+  // How far outside the scroll viewport a message section still counts as
+  // "visible" and keeps getting DOM writes. Wide enough that a fast scroll
+  // never outruns the repaint.
+  VIEWPORT_MARGIN:     '400px 0px',
   ALERT_RE:            /_a\d{3}_/,
   CHAR_RE:             /^(.+)Char(\d+)$/,
 };
 
 // ===========================================================
+// Shared helpers
+// ===========================================================
+
+// Send a command only if the socket is actually up.
+function sendJson(sock, obj) {
+  if (sock && sock.readyState === WebSocket.OPEN) sock.send(JSON.stringify(obj));
+}
+
+// Flash bookkeeping. The old code did `el.classList.remove(c); void el.offsetWidth;
+// el.classList.add(c)` plus a setTimeout per element — a forced synchronous
+// reflow and a timer for every changed byte AND every changed bit, which is what
+// actually melted the raw tab. These classes are plain background swaps (no
+// keyframes), so no reflow is needed to restart them; expiry is swept in bulk
+// from the same rAF that paints.
+function makeFlasher(cls, ms) {
+  const live = new Map();  // element -> expiry timestamp
+  return {
+    flash(el) {
+      if (!live.has(el)) el.classList.add(cls);
+      live.set(el, performance.now() + ms);
+    },
+    sweep(now) {
+      if (!live.size) return;
+      for (const [el, until] of live) {
+        if (now >= until) { el.classList.remove(cls); live.delete(el); }
+      }
+    },
+    clear() { live.forEach((_, el) => el.classList.remove(cls)); live.clear(); },
+    get size() { return live.size; },
+  };
+}
+
+// ===========================================================
 // Tab switching
 // ===========================================================
-document.querySelectorAll('.tab-btn').forEach(btn => {
-  btn.addEventListener('click', () => {
-    const tab = btn.dataset.tab;
-    document.querySelectorAll('.tab-btn').forEach(b => b.classList.toggle('active', b === btn));
-    document.querySelectorAll('.tab-view').forEach(v => v.classList.toggle('active', v.id === `tab-${tab}`));
-    if (tab === 'explorer' && !expLoaded) loadExplorer();
-  });
+let activeTab = 'live';
+
+// Streams for tabs the user isn't looking at are paused server-side, so a busy
+// bus costs nothing while you're on another tab or another window.
+function updateStreamPause() {
+  const away = document.hidden;
+  sendJson(ws, { type: 'pause', on: away || activeTab !== 'live' });
+  if (window.__rawPause) window.__rawPause(away || activeTab !== 'raw');
+}
+
+// One-shot initializers keyed by tab name, run the first time a tab is shown,
+// so a tab you never open costs nothing -- no socket, no fetch. Tabs register
+// their own below (see the Raw Frames and ODIN sections).
+const tabInit = {
+  explorer: () => { if (!expLoaded) loadExplorer(); },
+};
+
+// TEMPORARY: tabs whose buttons are hidden. The view and its lazy initializer
+// stay in place -- an unshown tab never opens its socket -- so restoring one is
+// just removing it from this set.
+const HIDDEN_TABS = new Set(['raw']);
+
+document.querySelectorAll('.tab-btn').forEach(b => {
+  if (HIDDEN_TABS.has(b.dataset.tab)) b.style.display = 'none';
 });
+
+function selectTab(tab) {
+  activeTab = tab;
+  document.querySelectorAll('.tab-btn').forEach(b => b.classList.toggle('active', b.dataset.tab === tab));
+  document.querySelectorAll('.tab-view').forEach(v => v.classList.toggle('active', v.id === `tab-${tab}`));
+  const init = tabInit[tab];
+  if (init) { delete tabInit[tab]; init(); }
+  // Keep the URL addressable, so a reload (or a shared link) lands on the same
+  // tab instead of bouncing back to Live.
+  history.replaceState(null, '', tab === 'live' ? location.pathname : '#' + tab);
+  updateStreamPause();
+}
+
+document.querySelectorAll('.tab-btn').forEach(btn => {
+  btn.addEventListener('click', () => selectTab(btn.dataset.tab));
+});
+
+document.addEventListener('visibilitychange', updateStreamPause);
 
 // ===========================================================
 // LIVE TAB
@@ -711,7 +1217,8 @@ document.querySelectorAll('.tab-btn').forEach(btn => {
 let ws = null;
 const msgState   = new Map();
 const msgDom     = new Map();
-let frameCount = 0;
+let frameCount = 0;     // decoded messages seen (incl. ones coalesced server-side)
+let busRxAccum = 0;     // raw frames the backend read off the wire
 let lastFpsTs  = performance.now();
 
 const nodeList      = document.getElementById('node-list');
@@ -719,11 +1226,14 @@ const tableWrap     = document.getElementById('table-wrap');
 const placeholder   = document.getElementById('placeholder');
 const filterInput   = document.getElementById('filter-input');
 const alertFilterBtn = document.getElementById('alert-filter-btn');
+const txFilterBtn   = document.getElementById('tx-filter-btn');
 const statusDot     = document.getElementById('status-dot');
 const statusText    = document.getElementById('status-text');
 const fpsCounter    = document.getElementById('fps-counter');
 
 let alertFilterActive = false;
+let alertFilterDirty  = false;
+const liveFlash = makeFlasher('flash', CONFIG.FLASH_MS);
 
 function connect() {
   ws = new WebSocket(CONFIG.WS_URL);
@@ -731,6 +1241,7 @@ function connect() {
     statusDot.className = 'connected';
     statusText.textContent = 'connected';
     subscribe('');
+    updateStreamPause();
   };
   ws.onclose = () => {
     statusDot.className = '';
@@ -742,14 +1253,146 @@ function connect() {
     statusText.textContent = 'error';
   };
   ws.onmessage = (ev) => {
+    let msg;
     try {
-      const msg = JSON.parse(ev.data);
-      if      (msg.type === 'db')    handleDb(msg);
-      else if (msg.type === 'frame') handleFrame(msg);
+      msg = JSON.parse(ev.data);
     } catch (e) {
       console.error('Failed to parse WebSocket message:', e);
+      return;
+    }
+    switch (msg.type) {
+      case 'db':        handleDb(msg); applyServerConfig(msg); break;
+      case 'frames':    queueFrames(msg); break;
+      case 'tx_filter': applyTxFilterState(msg.on); break;
     }
   };
+}
+
+// ---- server-driven config (TX filter) ----
+let txIds = [];
+let txHidden = false;
+
+function applyServerConfig(msg) {
+  txIds = msg.tx_ids || [];
+  applyTxFilterState(!!msg.tx_hidden);
+}
+
+function applyTxFilterState(on) {
+  txHidden = on;
+  txFilterBtn.style.display = txIds.length ? '' : 'none';
+  txFilterBtn.classList.toggle('active', on);
+  txFilterBtn.textContent = on
+    ? `Our TX hidden (${txIds.length})`
+    : `Hide our TX (${txIds.length})`;
+  if (window.__rawTxState) window.__rawTxState(on, txIds);
+}
+
+txFilterBtn.addEventListener('click', () => {
+  sendJson(ws, { type: 'tx_filter', on: !txHidden });
+});
+window.__setTxFilter = (on) => sendJson(ws, { type: 'tx_filter', on });
+
+// ---- batched receive -> rAF paint ----
+// Nothing touches the DOM in onmessage. Batches are merged into a
+// latest-per-message map and applied once per animation frame, so an 80%-loaded
+// bus paints at 60 Hz instead of trying to paint thousands of times a second.
+const livePending = new Map();
+let liveRafQueued = false;
+
+function queueFrames(batch) {
+  busRxAccum += batch.rx || 0;
+  const frames = batch.frames || [];
+  for (let i = 0; i < frames.length; i++) {
+    livePending.set(frames[i].msg_id, frames[i]);
+  }
+  scheduleLiveFlush();
+}
+
+function scheduleLiveFlush() {
+  if (liveRafQueued) return;
+  liveRafQueued = true;
+  requestAnimationFrame(flushLive);
+}
+
+function flushLive(now) {
+  liveRafQueued = false;
+  const render = activeTab === 'live' && !document.hidden;
+  livePending.forEach(f => applyFrame(f, render));
+  livePending.clear();
+  liveFlash.sweep(now);
+  if (render && alertFilterActive && alertFilterDirty) {
+    alertFilterDirty = false;
+    applyFilter();
+  }
+  if (liveFlash.size) scheduleLiveFlush();  // keep sweeping until flashes expire
+}
+
+function applyFrame(msg, render) {
+  frameCount += msg.n || 1;
+  if (msg.unknown) ensureUnknownMsg(msg.msg_id);
+  const state = msgState.get(msg.msg_id);
+  if (!state) return;
+  state.lastTs = msg.timestamp;
+  // `same` = byte-identical payload; the backend skipped the decode, and no
+  // displayed value can have changed. Only liveness needed updating.
+  if (msg.same) return;
+  let dom = render ? msgDom.get(msg.msg_id) : null;
+  if (dom && !dom.visible) dom = null;  // off-screen: update state, skip the DOM
+
+  // An unknown id has no signal list to walk -- all we can show is the payload.
+  if (msg.unknown) {
+    const hex = (msg.data || [])
+      .map(b => b.toString(16).toUpperCase().padStart(2, '0')).join(' ');
+    const cur = state.signals.raw;
+    const changed = cur.value !== hex;
+    cur.value = hex;
+    const row = dom && dom.rows.raw;
+    if (row && row.valueTd.textContent !== hex) {
+      row.valueTd.textContent = hex;
+      if (changed) flashCell(row.valueTd);
+    }
+    return;
+  }
+
+  const updatedPrefixes = dom ? new Set() : null;
+
+  const sigs = msg.signals;
+  for (let i = 0; i < sigs.length; i++) {
+    const s = sigs[i];
+    const cur = state.signals[s.signal];
+    if (!cur) continue;
+    const changed = cur.value !== s.value || cur.label !== s.label;
+    cur.value = s.value;
+    cur.label = s.label || null;
+    if (changed && alertFilterActive && CONFIG.ALERT_RE.test(s.signal)) alertFilterDirty = true;
+    if (!dom) continue;
+
+    const row = dom.rows[s.signal];
+    if (!row) continue;
+    const formatted = (s.label && !s.units) ? s.label : formatValue(s.value, s.units);
+    if (row.valueTd.textContent !== formatted) {
+      row.valueTd.textContent = formatted;
+      if (changed) flashCell(row.valueTd);
+    }
+    const label = (s.label && !s.units) ? '' : (s.label || '');
+    if (row.labelTd.textContent !== label) row.labelTd.textContent = label;
+
+    const m = CONFIG.CHAR_RE.exec(s.signal);
+    if (m) updatedPrefixes.add(m[1]);
+  }
+
+  if (dom) {
+    updatedPrefixes.forEach(prefix => {
+      const key = `__str__${prefix}`;
+      const row = dom.rows[key];
+      if (!row) return;
+      const str = assembleString(prefix, row.charGroup, state);
+      if (row.valueTd.textContent !== str) {
+        row.valueTd.textContent = str;
+        flashCell(row.valueTd);
+      }
+    });
+  }
 }
 
 async function handleDb(msg) {
@@ -774,9 +1417,11 @@ async function handleDb(msg) {
   try {
     const res = await fetch(CONFIG.API_DB);
     const db = await res.json();
+    sectionObs.disconnect();
     msgState.clear();
     msgDom.clear();
     tableWrap.innerHTML = '';
+    unknownMsgList = null;   // wiped with the table; rebuilt on the next unknown id
 
     msg.nodes.forEach(node => {
       const messages = db[node];
@@ -816,48 +1461,108 @@ async function handleDb(msg) {
   }
 }
 
-function handleFrame(msg) {
-  frameCount++;
-  const state = msgState.get(msg.msg_id);
-  if (!state) return;
-  state.lastTs = msg.timestamp;
-  const dom = msgDom.get(msg.msg_id);
-  const updatedPrefixes = new Set();
-
-  msg.signals.forEach(s => {
-    const cur = state.signals[s.signal];
-    if (!cur) return;
-    const changed = cur.value !== s.value || cur.label !== s.label;
-    cur.value = s.value;
-    cur.label = s.label || null;
-    if (!dom) return;
-    const row = dom.rows[s.signal];
-    if (!row) return;
-    const formatted = (s.label && !s.units) ? s.label : formatValue(s.value, s.units);
-    if (row.valueTd.textContent !== formatted) {
-      row.valueTd.textContent = formatted;
-      if (changed) flashCell(row.valueTd);
-    }
-    row.labelTd.textContent = (s.label && !s.units) ? '' : (s.label || '');
-
-    const m = CONFIG.CHAR_RE.exec(s.signal);
-    if (m) updatedPrefixes.add(m[1]);
-  });
-
-  if (dom) {
-    updatedPrefixes.forEach(prefix => {
-      const key = `__str__${prefix}`;
-      const row = dom.rows[key];
-      if (!row) return;
-      const str = assembleString(prefix, row.charGroup, state);
-      if (row.valueTd.textContent !== str) {
-        row.valueTd.textContent = str;
-        flashCell(row.valueTd);
-      }
-    });
+// ---- Viewport gating ------------------------------------------------------
+// Every message of every node is materialized into the table at load, but only
+// a couple of screens' worth is ever on display. Writing textContent and flash
+// classes into rows nobody can see was the bulk of the per-tick DOM cost on a
+// busy bus. `msgState` is still updated for every frame -- only the DOM write
+// is skipped -- so filters, the alert view and liveness stay correct, and a
+// section repaints from state as soon as it scrolls back in. Sections hidden
+// by applyFilter stop intersecting too, so they fall out for free.
+//
+// Sections start visible and the observer switches them OFF: the failure mode of
+// a gate that starts closed is a permanently blank section, indistinguishable
+// from the viewer having lost the node. Starting open means the worst case is
+// simply the un-gated behaviour.
+const sectionObs = new IntersectionObserver(entries => {
+  for (const e of entries) {
+    const dom = msgDom.get(+e.target.dataset.msgId);
+    if (!dom) continue;
+    const wasVisible = dom.visible;
+    dom.visible = e.isIntersecting;
+    if (dom.visible && !wasVisible) repaintSection(+e.target.dataset.msgId, dom);
   }
+}, { root: tableWrap, rootMargin: CONFIG.VIEWPORT_MARGIN });
 
-  if (alertFilterActive) applyFilter();
+function updateAge(dom, state, now) {
+  if (state.lastTs === null) return;
+  const age = now - state.lastTs;
+  dom.ageEl.textContent = age < 10 ? `${age.toFixed(1)}s` : `${age.toFixed(0)}s`;
+  const staleThreshold = state.cycleTime ? (state.cycleTime * CONFIG.STALE_MULTIPLIER) / 1000 : 1.0;
+  dom.ageEl.className = 'msg-age' + (age > staleThreshold ? ' stale' : '');
+}
+
+// Bring a section's rows up to date with state after it was skipped. No
+// flashing: those values changed while it was off-screen, so lighting them all
+// up on scroll-in would be noise, not signal.
+function repaintSection(id, dom) {
+  const state = msgState.get(id);
+  if (!state) return;
+  for (const sig in dom.rows) {
+    const row = dom.rows[sig];
+    if (row.charGroup) {
+      row.valueTd.textContent = assembleString(sig.replace('__str__', ''), row.charGroup, state);
+      continue;
+    }
+    const cur = state.signals[sig];
+    if (!cur) continue;
+    row.valueTd.textContent = (cur.label && !cur.units) ? cur.label : formatValue(cur.value, cur.units);
+    row.labelTd.textContent = (cur.label && !cur.units) ? '' : (cur.label || '');
+  }
+  updateAge(dom, state, Date.now() / 1000);
+}
+
+// ---- ids the signal DB doesn't carry -------------------------------------
+// The server forwards these tagged unknown:1 with their raw payload rather than
+// dropping them, because a frame hidden by the viewer is indistinguishable from
+// a node that has stopped transmitting. They get a synthetic node group built on
+// first sight, appended after the DB's nodes.
+const UNKNOWN_NODE = 'unknown';
+let unknownMsgList = null;
+
+function ensureUnknownHome() {
+  if (unknownMsgList && unknownMsgList.isConnected) return;
+
+  const header = document.createElement('div');
+  header.className = 'node-section-header';
+  header.id = `node-${UNKNOWN_NODE}`;
+  header.textContent = `${UNKNOWN_NODE} — not in the signal DB`;
+  tableWrap.appendChild(header);
+
+  const item = document.createElement('div');
+  const btn = document.createElement('button');
+  btn.className = 'node-btn';
+  btn.textContent = UNKNOWN_NODE;
+  btn.addEventListener('click', () => selectNode(UNKNOWN_NODE));
+  unknownMsgList = document.createElement('div');
+  unknownMsgList.className = 'msg-list';
+  unknownMsgList.dataset.node = UNKNOWN_NODE;
+  item.appendChild(btn);
+  item.appendChild(unknownMsgList);
+  nodeList.appendChild(item);
+}
+
+function ensureUnknownMsg(msgId) {
+  if (msgState.has(msgId)) return;
+  ensureUnknownHome();
+  const hex = `0x${msgId.toString(16).toUpperCase().padStart(3, '0')}`;
+  msgState.set(msgId, {
+    name: hex,
+    lastTs: null,
+    cycleTime: 0,
+    signals: { raw: { value: '—', label: null, units: '' } },
+  });
+  buildMsgSection({ id: msgId, name: `${hex} · undecoded`, signals: [{ name: 'raw', units: '' }] });
+
+  const mb = document.createElement('button');
+  mb.className = 'msg-btn';
+  mb.textContent = hex;
+  const tag = document.createElement('span');
+  tag.className = 'msg-btn-id';
+  tag.textContent = 'undecoded';
+  mb.appendChild(tag);
+  mb.addEventListener('click', () => scrollToMsg(msgId));
+  unknownMsgList.appendChild(mb);
 }
 
 function buildMsgSection(m) {
@@ -921,26 +1626,32 @@ function buildMsgSection(m) {
 
   section.appendChild(table);
   tableWrap.appendChild(section);
-  msgDom.set(m.id, { section, ageEl, rows, charGroups });
+  msgDom.set(m.id, { section, ageEl, rows, charGroups, visible: true });
+  sectionObs.observe(section);
 }
 
 setInterval(() => {
   const now = Date.now() / 1000;
   msgDom.forEach((dom, id) => {
+    if (!dom.visible) return;
     const state = msgState.get(id);
-    if (!state || state.lastTs === null) return;
-    const age = now - state.lastTs;
-    dom.ageEl.textContent = age < 10 ? `${age.toFixed(1)}s` : `${age.toFixed(0)}s`;
-    const staleThreshold = state.cycleTime ? (state.cycleTime * CONFIG.STALE_MULTIPLIER) / 1000 : 1.0;
-    dom.ageEl.className = 'msg-age' + (age > staleThreshold ? ' stale' : '');
+    if (!state) return;
+    updateAge(dom, state, now);
   });
 }, CONFIG.AGE_INTERVAL_MS);
 
 setInterval(() => {
   const now = performance.now();
   const elapsed = (now - lastFpsTs) / 1000;
-  fpsCounter.textContent = `${(frameCount / elapsed).toFixed(0)} fps`;
+  const decRate = frameCount / elapsed;
+  const busRate = busRxAccum / elapsed;
+  // Bus rate is what the backend actually read; decoded rate counts messages
+  // matched to the DB — both are pre-coalescing, so they don't lie about load.
+  fpsCounter.textContent = busRxAccum
+    ? `${busRate.toFixed(0)} f/s bus · ${decRate.toFixed(0)}/s decoded`
+    : `${decRate.toFixed(0)}/s decoded`;
   frameCount = 0;
+  busRxAccum = 0;
   lastFpsTs  = now;
 }, CONFIG.FPS_INTERVAL_MS);
 
@@ -1059,10 +1770,7 @@ function formatValue(v, _units) {
 }
 
 function flashCell(td) {
-  td.classList.remove('flash');
-  void td.offsetWidth;
-  td.classList.add('flash');
-  setTimeout(() => td.classList.remove('flash'), CONFIG.FLASH_MS);
+  liveFlash.flash(td);
 }
 
 connect();
@@ -1203,7 +1911,7 @@ function renderExp() {
 // RAW FRAMES TAB
 // ===========================================================
 (function () {
-  const WS_RAW_URL     = `ws://${location.host}/ws-raw`;
+  const WS_RAW_URL     = '/ws-raw';
   const RECONNECT_MS   = 1500;
   const BYTE_FLASH_MS  = 200;
   const BIT_FLASH_MS   = 200;
@@ -1212,20 +1920,29 @@ function renderExp() {
   const rawIdFilter    = document.getElementById('raw-id-filter');
   const rawClearBtn    = document.getElementById('raw-clear-btn');
   const rawFreezeBtn   = document.getElementById('raw-freeze-btn');
+  const rawTxBtn       = document.getElementById('raw-tx-filter-btn');
   const rawCardsGrid   = document.getElementById('raw-cards-grid');
   const rawStatusDot   = document.getElementById('raw-status-dot');
   const rawStatusText  = document.getElementById('raw-status-text');
+  const rawRxCounter   = document.getElementById('raw-rx-counter');
   const rawIdList      = document.getElementById('raw-id-list');
   const rawShowAll     = document.getElementById('raw-show-all');
   const rawHideAll     = document.getElementById('raw-hide-all');
 
   let rawWs        = null;
   let frozen       = false;
+  let paused       = false;
   let filterText   = '';
+  let rawTxHidden  = false;
+  let rawTxCount   = 0;
+  let rxAccum      = 0;
   const hiddenIds  = new Set();  // CAN IDs the user has unchecked
 
-  // Map: CAN ID (number) -> { card dom, prevData, timestamps[] for rate, byteEls[], bitEls[][] }
+  // Map: CAN ID (number) -> { card dom, prevData, count, byteEls[], bitEls[][] }
   const rawCards = new Map();
+
+  const byteFlash = makeFlasher('byte-flash', BYTE_FLASH_MS);
+  const bitFlash  = makeFlasher('bit-flash', BIT_FLASH_MS);
 
   // ---- WebSocket connection ----
   function connectRaw() {
@@ -1233,6 +1950,8 @@ function renderExp() {
     rawWs.onopen = () => {
       rawStatusDot.className = 'connected';
       rawStatusText.textContent = 'connected';
+      pushMute();
+      pushPause();
     };
     rawWs.onclose = () => {
       rawStatusDot.className = '';
@@ -1244,20 +1963,97 @@ function renderExp() {
       rawStatusText.textContent = 'error';
     };
     rawWs.onmessage = (ev) => {
-      if (frozen) return;
-      let frame;
-      try { frame = JSON.parse(ev.data); } catch { return; }
-      handleRawFrame(frame);
+      let msg;
+      try { msg = JSON.parse(ev.data); } catch { return; }
+      if (msg.type === 'frames') {
+        if (!frozen) queueRawFrames(msg);
+      } else if (msg.type === 'hello') {
+        rawTxHidden = !!msg.tx_hidden;
+        rawTxCount  = (msg.tx_ids || []).length;
+        renderTxBtn();
+      } else if (msg.type === 'tx_filter') {
+        rawTxHidden = !!msg.on;
+        renderTxBtn();
+      }
     };
   }
 
-  // ---- Frame handling ----
-  function handleRawFrame(frame) {
-    const { id, data, ts } = frame;
-    if (!rawCards.has(id)) {
-      createCard(id, data);
+  // ---- Server-side stream control ----
+  // Muting and pausing happen on the backend, so filtered-out traffic costs no
+  // bandwidth, no JSON parse, and no DOM work — unlike the old display:none,
+  // which still paid for every hidden frame.
+  function pushMute() {
+    sendJson(rawWs, { type: 'mute', ids: [...hiddenIds] });
+  }
+
+  function pushPause() {
+    sendJson(rawWs, { type: 'pause', on: paused || frozen });
+  }
+
+  window.__rawPause = (on) => {
+    if (paused === on) return;
+    paused = on;
+    pushPause();
+  };
+
+  window.__rawTxState = (on, ids) => {
+    rawTxHidden = on;
+    rawTxCount = ids.length;
+    renderTxBtn();
+  };
+
+  function renderTxBtn() {
+    rawTxBtn.style.display = rawTxCount ? '' : 'none';
+    rawTxBtn.classList.toggle('active', rawTxHidden);
+    rawTxBtn.textContent = rawTxHidden
+      ? `Our TX hidden (${rawTxCount})`
+      : `Hide our TX (${rawTxCount})`;
+  }
+
+  rawTxBtn.addEventListener('click', () => {
+    sendJson(rawWs, { type: 'tx_filter', on: !rawTxHidden });
+  });
+
+  // ---- Batched receive -> rAF paint ----
+  const rawPending = new Map();  // id -> newest frame in this paint window
+  let rawRafQueued = false;
+
+  function queueRawFrames(batch) {
+    rxAccum += batch.rx || 0;
+    const frames = batch.frames || [];
+    for (let i = 0; i < frames.length; i++) {
+      const f = frames[i];
+      const prev = rawPending.get(f.id);
+      if (prev) {
+        f.n = (f.n || 1) + (prev.n || 1);  // keep the arrival count honest
+        if (!f.data) f.data = prev.data;   // liveness tick after a real update
+      }
+      rawPending.set(f.id, f);
     }
-    updateCard(id, data);
+    scheduleRawFlush();
+  }
+
+  function scheduleRawFlush() {
+    if (rawRafQueued) return;
+    rawRafQueued = true;
+    requestAnimationFrame(flushRaw);
+  }
+
+  function flushRaw(now) {
+    rawRafQueued = false;
+    const render = activeTab === 'raw' && !document.hidden;
+    rawPending.forEach(f => {
+      let state = rawCards.get(f.id);
+      if (!state) state = createCard(f.id, f.data);  // undefined data -> 8 boxes
+      state.count += f.n || 1;
+      if (!f.data) return;  // liveness tick: bytes unchanged, nothing to repaint
+      if (render && state.visible) updateCard(state, f.data);
+      else state.prevData = f.data;  // resync without painting
+    });
+    rawPending.clear();
+    byteFlash.sweep(now);
+    bitFlash.sweep(now);
+    if (byteFlash.size || bitFlash.size) scheduleRawFlush();
   }
 
   // ---- Card creation ----
@@ -1344,6 +2140,7 @@ function renderExp() {
       if (cb.checked) hiddenIds.delete(id);
       else hiddenIds.add(id);
       applyRawFilter();
+      pushMute();
     });
 
     const lbl = document.createElement('span');
@@ -1374,76 +2171,70 @@ function renderExp() {
     if (!rowInserted) rawIdList.appendChild(row);
     row.dataset.rawId = id;
 
-    rawCards.set(id, {
+    const state = {
       card,
       rateEl,
       sidebarRate,
       byteEls,
       bitEls,
       prevData: null,
-      timestamps: [],
-    });
+      count: 0,      // arrivals since the last rate tick (server-counted)
+      rate: -1,
+      visible: true,
+    };
+    rawCards.set(id, state);
 
     applyRawFilter();
+    return state;
   }
 
   // ---- Card update ----
-  function updateCard(id, data) {
-    const state = rawCards.get(id);
-    if (!state) return;
-
-    // Rate tracking
-    const now = performance.now();
-    state.timestamps.push(now);
-    // Prune old timestamps outside the window
-    const cutoff = now - RATE_WINDOW_MS;
-    while (state.timestamps.length && state.timestamps[0] < cutoff) {
-      state.timestamps.shift();
-    }
-    const rate = state.timestamps.length;
-    state.rateEl.textContent = `${rate}/s`;
-    state.sidebarRate.textContent = `${rate}/s`;
-
+  // Only ever called for a visible card on an active tab, at most once per
+  // animation frame.
+  function updateCard(state, data) {
     const prev = state.prevData;
 
-    for (let b = 0; b < data.length; b++) {
+    const n = Math.min(data.length, state.byteEls.length);  // DLC can vary per frame
+    for (let b = 0; b < n; b++) {
       const val = data[b];
       const prevVal = prev ? prev[b] : null;
-      const byteChanged = prevVal === null || val !== prevVal;
+      if (val === prevVal) continue;  // nothing to paint for this byte
 
       const { box, hexEl } = state.byteEls[b];
       hexEl.textContent = val.toString(16).toUpperCase().padStart(2, '0');
-
-      if (byteChanged) {
-        // Flash byte box yellow
-        box.classList.remove('byte-flash');
-        void box.offsetWidth; // reflow to restart animation
-        box.classList.add('byte-flash');
-        setTimeout(() => box.classList.remove('byte-flash'), BYTE_FLASH_MS);
-      }
+      byteFlash.flash(box);
 
       // Update bits (MSB = bit 7 = index 0 in our array)
       const bits = state.bitEls[b];
       for (let bit = 7; bit >= 0; bit--) {
-        const bitIdx = 7 - bit; // 0 = MSB
-        const sq = bits[bitIdx];
         const isOn = (val >> bit) & 1;
-        const wasOn = prev ? (prev[b] >> bit) & 1 : -1;
-        const bitChanged = wasOn !== isOn;
-
+        const wasOn = prevVal === null ? -1 : (prevVal >> bit) & 1;
+        if (wasOn === isOn) continue;
+        const sq = bits[7 - bit];  // 0 = MSB
         sq.classList.toggle('on', !!isOn);
-
-        if (bitChanged) {
-          sq.classList.remove('bit-flash');
-          void sq.offsetWidth;
-          sq.classList.add('bit-flash');
-          setTimeout(() => sq.classList.remove('bit-flash'), BIT_FLASH_MS);
-        }
+        bitFlash.flash(sq);
       }
     }
 
-    state.prevData = data.slice();
+    state.prevData = data;
   }
+
+  // ---- Rate display ----
+  // Driven by the backend's per-ID arrival counts, so it reports the true bus
+  // rate rather than however many updates the UI happened to receive.
+  setInterval(() => {
+    rawCards.forEach(state => {
+      const rate = state.count;
+      state.count = 0;
+      if (rate === state.rate) return;
+      state.rate = rate;
+      const txt = `${rate}/s`;
+      state.rateEl.textContent = txt;
+      state.sidebarRate.textContent = txt;
+    });
+    rawRxCounter.textContent = rxAccum ? `${rxAccum} f/s bus` : '';
+    rxAccum = 0;
+  }, RATE_WINDOW_MS);
 
   // ---- Filter ----
   function applyRawFilter() {
@@ -1452,7 +2243,10 @@ function renderExp() {
       const idHex = id.toString(16).toLowerCase();
       const matchesText = !f || idHex.includes(f);
       const show = matchesText && !hiddenIds.has(id);
-      state.card.style.display = show ? '' : 'none';
+      if (state.visible !== show) {
+        state.visible = show;
+        state.card.style.display = show ? '' : 'none';
+      }
     });
   }
 
@@ -1464,41 +2258,759 @@ function renderExp() {
   rawClearBtn.addEventListener('click', () => {
     rawCards.clear();
     hiddenIds.clear();
+    rawPending.clear();
+    byteFlash.clear();
+    bitFlash.clear();
     rawCardsGrid.innerHTML = '';
     rawIdList.innerHTML = '';
+    pushMute();
   });
 
   rawShowAll.addEventListener('click', () => {
     hiddenIds.clear();
     rawIdList.querySelectorAll('input[type=checkbox]').forEach(cb => cb.checked = true);
     applyRawFilter();
+    pushMute();
   });
 
   rawHideAll.addEventListener('click', () => {
     rawCards.forEach((_, id) => hiddenIds.add(id));
     rawIdList.querySelectorAll('input[type=checkbox]').forEach(cb => cb.checked = false);
     applyRawFilter();
+    pushMute();
   });
 
   rawFreezeBtn.addEventListener('click', () => {
     frozen = !frozen;
     rawFreezeBtn.classList.toggle('active', frozen);
     rawFreezeBtn.textContent = frozen ? 'Unfreeze' : 'Freeze';
+    pushPause();  // freeze stops the stream at the source, not just the paint
   });
 
-  // Connect when the Raw tab is first activated (lazy), but also connect eagerly
-  // so rate data starts accumulating. We connect on first tab activation.
-  let rawConnected = false;
-
-  document.querySelectorAll('.tab-btn').forEach(btn => {
-    btn.addEventListener('click', () => {
-      if (btn.dataset.tab === 'raw' && !rawConnected) {
-        rawConnected = true;
-        connectRaw();
-      }
-    });
-  });
+  // Open the raw socket the first time the tab is shown.
+  tabInit.raw = connectRaw;
 })();
+// ===========================================================
+// ODIN + DID TABS
+// ===========================================================
+// Lifted wholesale from the old standalone odin.html. Wrapped in an IIFE
+// because it brings its own $/el/fmt helpers, which would otherwise collide
+// with the viewer's globals. Boots lazily on first activation of either tab:
+// until then it opens no socket and fetches no procedure list.
+(function () {
+  const $ = (s, r=document) => r.querySelector(s);
+  const el = (tag, cls, txt) => { const e = document.createElement(tag); if (cls) e.className = cls; if (txt != null) e.textContent = txt; return e; };
+  // Display any value: objects/arrays as JSON (else "[object Object]"), null as ''.
+  const fmt = (v) => v == null ? '' : (typeof v === 'object' ? JSON.stringify(v) : String(v));
+  async function jget(u) { const r = await fetch(u); return { ok: r.ok, status: r.status, data: await r.json() }; }
+  async function jpost(u, body) {
+    const r = await fetch(u, { method: 'POST', headers: {'Content-Type':'application/json'}, body: JSON.stringify(body) });
+    return { ok: r.ok, status: r.status, data: await r.json() };
+  }
+
+  // The UDS node list is static config (nodes.json), shared by the DID tab and
+  // the low-level panel. Fetched once; both pickers fill from it. If the endpoint
+  // is unavailable the selects stay empty rather than silently offering nothing
+  // that works.
+  let udsNodes = null;
+
+  async function loadUdsNodes() {
+    if (udsNodes) return udsNodes;
+    try {
+      const { ok, data } = await jget('/api/uds/nodes');
+      udsNodes = ok && Array.isArray(data) ? data : [];
+    } catch (e) {
+      udsNodes = [];
+    }
+    return udsNodes;
+  }
+
+  // Fill a <select> with the node list, preserving `selected` if it still exists.
+  async function fillNodeSelect(sel, selected) {
+    const nodes = await loadUdsNodes();
+    sel.innerHTML = '';
+    const blank = el('option', null, nodes.length ? 'node…' : 'no nodes available');
+    blank.value = '';
+    sel.append(blank);
+    for (const n of nodes) {
+      const o = el('option', null, `${n.node}  ${n.tx}/${n.rx}`);
+      o.value = n.node;
+      sel.append(o);
+    }
+    if (selected && nodes.some(n => n.node === selected)) sel.value = selected;
+  }
+
+  /* ===================== ODIN ===================== */
+  let procs = [];
+  let selectedProc = null;
+  let seenTimer = null;   // polls /api/seen-signals to color the requires-on-bus rows
+
+  async function loadProcs() {
+    const list = $('#proc-list');
+    try {
+      const { ok, data } = await jget('/api/odin/procedures');
+      if (!ok) { list.innerHTML = ''; list.append(el('div', 'placeholder', (data && data.error) || 'failed to load')); return; }
+      procs = data;
+      renderProcs();
+    } catch (e) {
+      list.innerHTML = ''; list.append(el('div', 'placeholder', 'server unreachable'));
+    }
+  }
+
+  function renderProcs() {
+    const q = $('#proc-filter').value.trim().toLowerCase();
+    const list = $('#proc-list');
+    list.innerHTML = '';
+    // Pinned above the procedures, and never filtered out: the raw UDS primitives
+    // the procedures are composed from. When you are bringing a bench ECU up, no
+    // packaged procedure covers "hold this node in its bootloader".
+    list.append(el('div', 'section-label', 'low level'));
+    const llb = el('button', 'list-item');
+    llb.append(el('div', 'li-title', 'UDS operations'));
+    llb.append(el('div', 'li-sub', 'session · security · reset · bootloader · DTCs'));
+    llb.onclick = () => selectLowLevel(llb);
+    list.append(llb);
+    list.append(el('div', 'section-label', 'procedures'));
+    const shown = procs.filter(p =>
+      !q || p.name.toLowerCase().includes(q) || (p.title || '').toLowerCase().includes(q));
+    if (!shown.length) { list.append(el('div', 'placeholder', 'no matches')); return; }
+    for (const p of shown) {
+      const b = el('button', 'list-item');
+      b.append(el('div', 'li-title', p.title || p.name));
+      const sub = el('div', 'li-sub', p.name);
+      if (p.valid_states && p.valid_states.length) {
+        const t = el('span', 'li-tag', p.valid_states.join('|'));
+        sub.append(t);
+      }
+      b.append(sub);
+      b.onclick = () => selectProc(p, b);
+      list.append(b);
+    }
+  }
+  $('#proc-filter').oninput = renderProcs;
+
+  function selectProc(p, btn) {
+    selectedProc = p;
+    document.querySelectorAll('#proc-list .list-item').forEach(x => x.classList.toggle('active', x === btn));
+    $('#proc-title').textContent = p.title || p.name;
+    $('#proc-sub').textContent = p.basename;
+    const body = $('#odin-body');
+    body.innerHTML = '';
+    const row = el('div', 'row');
+    const runBtn = el('button', 'btn', 'Run procedure');
+    runBtn.id = 'run-btn';
+    runBtn.onclick = () => runProc(p);
+    row.append(runBtn);
+    const res = el('span'); res.id = 'run-result';
+    row.append(res);
+    body.append(row);
+    if (p.valid_states && p.valid_states.length) {
+      const vs = el('div', 'kv');
+      vs.append(el('span', 'k', 'required states'));
+      vs.append(el('span', null, p.valid_states.join(', ')));
+      body.append(vs);
+    }
+    if (p.principals && p.principals.length) {
+      const pr = el('div', 'kv');
+      pr.append(el('span', 'k', 'principals'));
+      pr.append(el('span', null, p.principals.join(', ')));
+      body.append(pr);
+    }
+    // "Requires on bus": what the sim / a real ECU must provide before this proc runs.
+    const reqs = el('div', 'reqs'); reqs.id = 'proc-reqs';
+    reqs.append(el('h3', null, 'Requires on bus'));
+    reqs.append(el('div', 'muted', 'loading…'));
+    body.append(reqs);
+    loadRequirements(p, reqs);
+    const log = el('div', 'log'); log.id = 'run-log';
+    log.append(el('div', 'ev-trace', '— run log —'));
+    body.append(log);
+    const metrics = el('div'); metrics.id = 'run-metrics';
+    body.append(metrics);
+  }
+
+  // Fetch + render the proc's static "requires on bus" readout into `container`.
+  // On-demand (the per-proc graph walk isn't free); the server caches by basename.
+  async function loadRequirements(p, container) {
+    try {
+      const { ok, data } = await jget('/api/odin/requirements?procedure=' + encodeURIComponent(p.basename));
+      if (selectedProc !== p) return;             // user moved on before it returned
+      if (!ok) return reqsMessage(container, (data && data.error) || 'unavailable');
+      renderRequirements(data, container);
+    } catch (e) {
+      if (selectedProc === p) reqsMessage(container, 'unavailable');
+    }
+  }
+
+  function reqsMessage(container, msg) {
+    container.innerHTML = '';
+    container.append(el('h3', null, 'Requires on bus'));
+    container.append(el('div', 'muted', msg));
+  }
+
+  function renderRequirements(req, container) {
+    container.innerHTML = '';
+    container.append(el('h3', null, 'Requires on bus'));
+    const buses = Object.keys(req.signals || {}).sort();
+    if (!buses.length && !(req.alerts || []).length) {
+      container.append(el('div', 'muted', 'no static CAN reads detected'));
+    }
+    for (const bus of buses) {
+      const g = el('div', 'bus-group');
+      g.append(el('div', 'bus-name', bus));
+      for (const sig of req.signals[bus]) {
+        const r = el('div', 'sig-row');
+        r.dataset.signal = sig.signal;            // colored below by live presence
+        r.append(el('span', 'sig-dot', '●'));
+        r.append(el('span', null, sig.signal));
+        r.append(el('span', 'sig-kind', sig.kind));
+        g.append(r);
+      }
+      container.append(g);
+    }
+    if ((req.alerts || []).length) {
+      const txt = req.alerts.map(a => (a.prefix || '*') + (a.bus ? '@' + a.bus : '')).join(', ');
+      addReqKV(container, 'alerts', txt);
+    }
+    const pre = req.preconditions || {};
+    addReqKV(container, 'application state', pre.application_state);
+    addReqKV(container, 'power state', pre.power_state);
+    addReqKV(container, 'UDS target nodes', req.nodes);
+    addReqKV(container, 'MCU data values', pre.cid_values);
+    if (req.dynamic_count) {
+      container.append(el('div', 'note',
+        req.dynamic_count + ' dynamic signal' + (req.dynamic_count > 1 ? 's' : '') +
+        ' unresolved — list is a lower bound'));
+    }
+    startSeenPolling(container);
+  }
+
+  // Live cross-reference: color each expected signal green (frame seen on the bus
+  // now) or red (missing), polling /api/seen-signals while this proc stays
+  // selected. If the endpoint isn't served the dots just stay neutral.
+  function startSeenPolling(container) {
+    if (seenTimer) { clearInterval(seenTimer); seenTimer = null; }
+    if (!container.querySelector('.sig-row')) return;
+    const apply = async () => {
+      if (!document.body.contains(container)) { clearInterval(seenTimer); seenTimer = null; return; }
+      if (document.hidden || activeTab !== 'odin') return;  // off-screen: skip the poll
+      try {
+        const { ok, data } = await jget('/api/seen-signals');
+        if (!ok || !data || !Array.isArray(data.signals)) return;
+        const seen = new Set(data.signals);
+        container.querySelectorAll('.sig-row').forEach(r => {
+          const present = seen.has(r.dataset.signal);
+          r.classList.toggle('seen', present);
+          r.classList.toggle('missing', !present);
+        });
+      } catch (e) { /* leave dots neutral */ }
+    };
+    apply();
+    seenTimer = setInterval(apply, 2000);
+  }
+
+  function addReqKV(container, key, val) {
+    if (val == null || (Array.isArray(val) && !val.length)) return;
+    const d = el('div', 'kv');
+    d.append(el('span', 'k', key));
+    d.append(el('span', null, Array.isArray(val) ? val.join(', ') : String(val)));
+    container.append(d);
+  }
+
+  function logEvent(kind, text) {
+    const log = $('#run-log');
+    if (!log) return;
+    const line = el('div', 'ev-' + kind, text);
+    log.append(line);
+    log.scrollTop = log.scrollHeight;
+  }
+
+  async function runProc(p) {
+    const btn = $('#run-btn');
+    btn.disabled = true;
+    $('#run-result').textContent = '';
+    $('#run-metrics').innerHTML = '';
+    const log = $('#run-log'); if (log) log.innerHTML = '';
+    logEvent('trace', '▶ running ' + p.basename + ' …');
+    try {
+      const { ok, status, data } = await jpost('/api/odin/run', { procedure: p.basename });
+      if (!ok) {
+        logEvent('error', '✖ ' + (data.error || ('HTTP ' + status)));
+        $('#run-result').innerHTML = '<span class="badge fail">error</span>';
+      } else {
+        renderRunResult(data);
+      }
+    } catch (e) {
+      logEvent('error', '✖ ' + e);
+    } finally {
+      btn.disabled = false;
+    }
+  }
+
+  function renderRunResult(res) {
+    const pass = res.passed;
+    $('#run-result').innerHTML = pass
+      ? '<span class="badge pass">pass · exit ' + res.exit_code + '</span>'
+      : '<span class="badge fail">fail · exit ' + res.exit_code + '</span>';
+    const m = $('#run-metrics');
+    m.innerHTML = '';
+    if (res.metrics && res.metrics.length) {
+      const t = el('table', 'grid');
+      const head = el('tr');
+      ['metric', 'value', 'rc', 'expected'].forEach(h => head.append(el('th', null, h)));
+      t.append(head);
+      for (const row of res.metrics) {
+        const tr = el('tr');
+        tr.append(el('td', null, row.metric));
+        tr.append(el('td', null, fmt(row.value)));
+        tr.append(el('td', null, fmt(row.result_code)));
+        tr.append(el('td', null, fmt(row.expected)));
+        t.append(tr);
+      }
+      m.append(el('div', 'section-label', 'metrics'));
+      m.append(t);
+    }
+    if (res.outputs && Object.keys(res.outputs).length) {
+      const t = el('table', 'grid');
+      const head = el('tr');
+      ['output', 'value'].forEach(h => head.append(el('th', null, h)));
+      t.append(head);
+      for (const k of Object.keys(res.outputs)) {
+        const tr = el('tr');
+        tr.append(el('td', null, k));
+        tr.append(el('td', null, fmt(res.outputs[k])));
+        t.append(tr);
+      }
+      m.append(el('div', 'section-label', 'outputs'));
+      m.append(t);
+    }
+  }
+
+  /* ===================== LOW-LEVEL UDS ===================== */
+  // Catalog-driven: /api/uds/ops describes each operation's fields and whether it
+  // is destructive, so adding an op server-side needs no change here.
+  let udsOps = null;
+  let udsNode = localStorage.getItem('tm3.udsNode') || '';
+  const udsCollapsed = new Set(readCollapsed());
+
+  function readCollapsed() {
+    try {
+      const v = JSON.parse(localStorage.getItem('tm3.udsCollapsed') || '[]');
+      return Array.isArray(v) ? v : [];
+    } catch (e) {
+      return [];
+    }
+  }
+
+  async function selectLowLevel(btn) {
+    selectedProc = null;
+    if (seenTimer) { clearInterval(seenTimer); seenTimer = null; }
+    document.querySelectorAll('#proc-list .list-item').forEach(x => x.classList.toggle('active', x === btn));
+    $('#proc-title').textContent = 'Low-level UDS';
+    $('#proc-sub').textContent = 'the primitives the ODIN procedures are built from';
+    const body = $('#odin-body');
+    body.innerHTML = '';
+
+    const nodeRow = el('div', 'field-row');
+    nodeRow.append(el('label', null, 'node'));
+    const nodeInput = el('select');
+    nodeInput.id = 'uds-node';
+    nodeInput.onchange = () => {
+      udsNode = nodeInput.value;
+      localStorage.setItem('tm3.udsNode', udsNode);
+      if (udsNode) clearNodeError();
+    };
+    nodeRow.append(nodeInput);
+    body.append(nodeRow);
+    fillNodeSelect(nodeInput, udsNode);
+
+    const nodeErr = el('div', 'uds-node-err');
+    nodeErr.id = 'uds-node-err';
+    body.append(nodeErr);
+
+    if (!udsOps) {
+      try {
+        const { ok, data } = await jget('/api/uds/ops');
+        if (!ok) { body.append(el('div', 'err', 'could not load the operation catalog')); return; }
+        udsOps = data;
+      } catch (e) {
+        body.append(el('div', 'err', 'server unreachable'));
+        return;
+      }
+    }
+
+    const out = el('div'); out.id = 'uds-out';
+    for (const group of [...new Set(udsOps.map(o => o.group))]) {
+      const ops = udsOps.filter(o => o.group === group);
+
+      const head = el('button', 'section-label uds-section-head');
+      head.type = 'button';
+      head.append(el('span', 'uds-caret', '▾'));
+      head.append(el('span', null, group));
+      head.append(el('span', 'uds-section-count', String(ops.length)));
+
+      const wrap = el('div', 'uds-grid');
+      for (const op of ops) wrap.append(udsOpCard(op, out));
+
+      if (udsCollapsed.has(group)) {
+        head.classList.add('collapsed');
+        wrap.classList.add('collapsed');
+      }
+      head.onclick = () => {
+        const nowCollapsed = wrap.classList.toggle('collapsed');
+        head.classList.toggle('collapsed', nowCollapsed);
+        if (nowCollapsed) udsCollapsed.add(group); else udsCollapsed.delete(group);
+        localStorage.setItem('tm3.udsCollapsed', JSON.stringify([...udsCollapsed]));
+      };
+
+      body.append(head);
+      body.append(wrap);
+    }
+    body.append(out);
+  }
+
+  function udsOpCard(op, out) {
+    const card = el('div', 'uds-op');
+    const head = el('div', 'uds-op-head');
+    head.append(el('span', 'uds-op-title', op.title));
+    card.append(head);
+    if (op.help) card.append(el('div', 'uds-help', op.help));
+
+    const inputs = {};
+    for (const f of (op.fields || [])) {
+      const fr = el('div', 'field-row');
+      fr.append(el('label', null, f.label));
+      let inp;
+      if (f.type === 'select') {
+        inp = el('select');
+        for (const o of f.options) { const opt = el('option', null, o); opt.value = o; inp.append(opt); }
+        inp.value = f.default;
+      } else if (f.type === 'bool') {
+        inp = el('input'); inp.type = 'checkbox'; inp.checked = !!f.default;
+      } else {
+        inp = el('input'); inp.type = 'text'; inp.value = f.default == null ? '' : String(f.default);
+      }
+      inputs[f.name] = { inp, type: f.type };
+      fr.append(inp);
+      card.append(fr);
+    }
+
+    const row = el('div', 'row');
+    const run = el('button', op.danger ? 'btn' : 'btn ghost', 'Run');
+    run.onclick = () => runUdsOp(op, inputs, run, out);
+    row.append(run);
+    card.append(row);
+    return card;
+  }
+
+  function clearNodeError() {
+    const inp = $('#uds-node');
+    if (inp) inp.classList.remove('invalid');
+    const err = $('#uds-node-err');
+    if (err) err.textContent = '';
+  }
+
+  // Returns the node name, or null having already told the user why not --
+  // marked on the field itself and scrolled into view, because the panel scrolls
+  // and a message appended at the bottom is a message nobody sees.
+  function requireNode() {
+    const inp = $('#uds-node');
+    const node = (inp.value || '').trim();
+    if (node) { clearNodeError(); return node; }
+    inp.classList.add('invalid');
+    $('#uds-node-err').textContent = 'enter a node first — e.g. DI, PMR, DIR';
+    inp.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+    inp.focus();
+    return null;
+  }
+
+  async function runUdsOp(op, inputs, btn, out) {
+    const node = requireNode();
+    if (!node) return;
+    // Resets and bootloader handovers reboot the ECU -- make them deliberate.
+    if (op.danger && !confirm(op.title + ' on ' + node + '?\n\n' + (op.help || ''))) return;
+    const args = {};
+    for (const [name, { inp, type }] of Object.entries(inputs)) {
+      args[name] = type === 'bool' ? inp.checked
+                 : type === 'int'  ? Number(inp.value)
+                 : inp.value;
+    }
+    btn.disabled = true;
+    udsMessage(out, 'muted', 'running ' + op.title + ' on ' + node + ' …');
+    try {
+      const { ok, status, data } = await jpost('/api/uds/op', { node, op: op.op, args });
+      if (!ok) udsMessage(out, 'err', (data && data.error) || ('HTTP ' + status));
+      else renderUdsResult(out, op, data.result);
+    } catch (e) {
+      udsMessage(out, 'err', String(e));
+    } finally {
+      btn.disabled = false;
+    }
+  }
+
+  function udsMessage(out, cls, msg) {
+    out.innerHTML = '';
+    out.append(el('div', 'section-label', 'result'));
+    out.append(el('div', cls, msg));
+  }
+
+  function renderUdsResult(out, op, res) {
+    out.innerHTML = '';
+    out.append(el('div', 'section-label', 'result · ' + op.title));
+    if (res == null || !Object.keys(res).length) { out.append(el('div', 'muted', 'ok — no data')); return; }
+    const t = el('table', 'grid');
+    const head = el('tr'); ['field', 'value'].forEach(h => head.append(el('th', null, h))); t.append(head);
+    for (const [k, v] of Object.entries(res)) {
+      if (k === 'dtcs' && Array.isArray(v)) continue;   // rendered as its own table
+      const tr = el('tr');
+      tr.append(el('td', null, k));
+      tr.append(el('td', null, fmt(v)));
+      t.append(tr);
+    }
+    out.append(t);
+    if (Array.isArray(res.dtcs) && res.dtcs.length) {
+      out.append(el('div', 'section-label', 'dtcs'));
+      const d = el('table', 'grid');
+      const h = el('tr'); ['dtc', 'status'].forEach(x => h.append(el('th', null, x))); d.append(h);
+      for (const row of res.dtcs) {
+        const tr = el('tr');
+        tr.append(el('td', null, row.dtc));
+        tr.append(el('td', null, row.status));
+        d.append(tr);
+      }
+      out.append(d);
+    }
+  }
+
+  /* ---- progress WebSocket ---- */
+  function connectWS() {
+    const ws = new WebSocket('/ws/odin');
+    ws.onopen = () => { $('#odin-conn').classList.add('up'); $('#odin-conn-txt').textContent = 'ws live'; };
+    ws.onclose = () => {
+      $('#odin-conn').classList.remove('up'); $('#odin-conn-txt').textContent = 'ws offline';
+      setTimeout(connectWS, 2000);
+    };
+    ws.onmessage = (e) => {
+      let d; try { d = JSON.parse(e.data); } catch { return; }
+      if (d.type === 'trace') logEvent('trace', '  '.repeat(d.depth || 0) + (d.message || ''));
+      else if (d.type === 'metric') logEvent('metric', '● ' + d.metric + ' = ' + fmt(d.value) + ' (rc ' + d.result_code + ')');
+      else if (d.type === 'done') logEvent('done', '✔ done · exit ' + d.exit_code);
+      else if (d.type === 'error') logEvent('error', '✖ ' + d.error);
+    };
+  }
+
+  /* ===================== DID ===================== */
+  let didCurrentNode = null;
+
+  async function loadDids() {
+    const node = $('#did-node').value;
+    if (!node) return;
+    didCurrentNode = node;
+    const list = $('#did-list');
+    list.innerHTML = ''; list.append(el('div', 'placeholder', 'loading…'));
+    try {
+      const { ok, status, data } = await jget('/api/did/' + encodeURIComponent(node));
+      if (!ok) { list.innerHTML = ''; list.append(el('div', 'placeholder', (data && data.error) || ('HTTP ' + status))); return; }
+      renderDidList(data);
+    } catch (e) {
+      list.innerHTML = ''; list.append(el('div', 'placeholder', 'server unreachable'));
+    }
+  }
+  $('#did-load').onclick = loadDids;
+  $('#did-node').addEventListener('change', () => { if ($('#did-node').value) loadDids(); });
+  fillNodeSelect($('#did-node'), null);
+
+  function renderDidList(dids) {
+    const list = $('#did-list');
+    list.innerHTML = '';
+    // Merge the read + write lists by DID id: a DID that is BOTH readable and
+    // writable appears ONCE, carrying both subspecs, so its detail view offers
+    // read AND write.
+    const merged = new Map();
+    for (const d of (dids.read || []))
+      merged.set(d.id, { id: d.id, name: d.name, hex_id: d.hex_id, read: d, write: null });
+    for (const d of (dids.write || [])) {
+      const m = merged.get(d.id) || { id: d.id, name: d.name, hex_id: d.hex_id, read: null };
+      m.write = d;
+      merged.set(d.id, m);
+    }
+    const items = [...merged.values()].sort((a, b) => a.name.localeCompare(b.name));
+    if (!items.length) { list.append(el('div', 'placeholder', 'no DIDs for this node')); return; }
+    for (const m of items) {
+      const b = el('button', 'list-item');
+      b.append(el('div', 'li-title', m.name));
+      const sub = el('div', 'li-sub', m.hex_id);
+      sub.append(el('span', 'li-tag', (m.read ? 'R' : '') + (m.write ? 'W' : '')));
+      b.append(sub);
+      b.onclick = () => selectDid(m, b);
+      list.append(b);
+    }
+  }
+
+  function selectDid(m, btn) {
+    document.querySelectorAll('#did-list .list-item').forEach(x => x.classList.toggle('active', x === btn));
+    const sl = [];
+    if (m.read && m.read.security_level) sl.push('read sl ' + m.read.security_level);
+    if (m.write && m.write.security_level) sl.push('write sl ' + m.write.security_level);
+    $('#did-title').textContent = m.name;
+    $('#did-sub').textContent = m.hex_id + (sl.length ? ' · ' + sl.join(' · ') : '');
+    const body = $('#did-body');
+    body.innerHTML = '';
+
+    // Always offer a read (0x22): read_did decodes ODJ fields when the DID declares
+    // a read subspec, else returns raw bytes -- writable/config DIDs are usually
+    // still physically readable, so a write-only-in-ODJ DID can still show its value.
+    {
+      body.append(el('div', 'section-label', m.read ? 'read (0x22)' : 'read (0x22 · raw)'));
+      const row = el('div', 'row');
+      const rb = el('button', 'btn', 'Read');
+      rb.onclick = () => doRead(m);
+      row.append(rb);
+      body.append(row);
+      const out = el('div'); out.id = 'did-read-out'; body.append(out);
+    }
+
+    if (m.write) {
+      body.append(el('div', 'section-label', 'write (0x2E)'));
+      const form = el('div'); form.id = 'did-form';
+      const fields = m.write.fields || [];
+      for (const f of fields) {
+        const fr = el('div', 'field-row');
+        fr.append(el('label', null, f));
+        const inp = el('input'); inp.type = 'text'; inp.dataset.field = f; inp.placeholder = 'value / enum';
+        fr.append(inp);
+        form.append(fr);
+      }
+      if (!fields.length) {
+        const fr = el('div', 'field-row');
+        fr.append(el('label', null, 'raw bytes (hex)'));
+        const inp = el('input'); inp.type = 'text'; inp.id = 'did-raw'; inp.placeholder = 'e.g. 01 ff';
+        fr.append(inp); form.append(fr);
+      }
+      body.append(form);
+      const row = el('div', 'row'); row.style.marginTop = '12px';
+      const wb = el('button', 'btn', 'Write DID');
+      wb.onclick = () => doWrite(m);
+      row.append(wb);
+      body.append(row);
+      const out = el('div'); out.id = 'did-write-out'; body.append(out);
+    }
+  }
+
+  async function doRead(m) {
+    const out = $('#did-read-out'); out.innerHTML = '';
+    try {
+      const { ok, status, data } = await jpost('/api/did/read', { node: didCurrentNode, did: m.name });
+      if (!ok) { out.append(el('div', 'err', data.error || ('HTTP ' + status))); return; }
+      const t = el('table', 'grid');
+      const head = el('tr'); ['field', 'value'].forEach(h => head.append(el('th', null, h))); t.append(head);
+      const fields = data.fields || {};
+      for (const k of Object.keys(fields)) {
+        const tr = el('tr'); tr.append(el('td', null, k)); tr.append(el('td', null, fmt(fields[k]))); t.append(tr);
+      }
+      if (!Object.keys(fields).length) {
+        const tr = el('tr'); tr.append(el('td', null, 'raw')); tr.append(el('td', null, data.raw)); t.append(tr);
+      }
+      out.append(el('div', 'section-label', 'response · raw ' + data.raw));
+      out.append(t);
+    } catch (e) { out.append(el('div', 'err', String(e))); }
+  }
+
+  async function doWrite(m) {
+    const out = $('#did-write-out'); out.innerHTML = '';
+    let values;
+    const raw = $('#did-raw');
+    if (raw) {
+      values = raw.value.trim();
+    } else {
+      values = {};
+      document.querySelectorAll('#did-form input[data-field]').forEach(inp => {
+        const v = inp.value.trim();
+        if (v === '') return;
+        values[inp.dataset.field] = /^-?\d+$/.test(v) ? parseInt(v, 10) : v;
+      });
+    }
+    try {
+      const { ok, status, data } = await jpost('/api/did/write', { node: didCurrentNode, did: m.name, values });
+      if (!ok) { out.append(el('div', 'err', data.error || ('HTTP ' + status))); return; }
+      const done = el('div', 'kv');
+      done.innerHTML = '<span class="badge pass">wrote</span> ' + data.hex_id
+        + ' — ' + data.bytes + ' (' + data.size + ' bytes)';
+      out.append(done);
+    } catch (e) { out.append(el('div', 'err', String(e))); }
+  }
+
+  /* ---- lazy boot: first time either ODIN or DID is shown ---- */
+  let booted = false;
+  const boot = () => {
+    if (booted) return;
+    booted = true;
+    loadProcs();
+    connectWS();
+  };
+  tabInit.odin = boot;
+  tabInit.did = boot;
+})();
+
+// ===========================================================
+// ALERTS TAB — human-readable faults + the ECUs' own alert log
+// ===========================================================
+// Backed by /api/alerts: the alert-matrix bits currently set, and the distinct
+// <NODE>_alertLog payloads decoded through the MCU alert catalog. The rendering
+// is shared with the Drive HUD (/alerts.js) so both pages read identically.
+(() => {
+  const badge     = document.getElementById('tab-alert-badge');
+  const statusEl  = document.getElementById('alerts-status');
+  const faultsBox = document.getElementById('al-faults');
+  const logBox    = document.getElementById('al-log');
+  const openAlert = TMAlerts.mountModal(
+    document.getElementById('alert-modal'),
+    document.getElementById('alert-title'),
+    document.getElementById('alert-body'),
+    document.getElementById('alert-close'));
+
+  async function refresh() {
+    let a;
+    try {
+      a = await (await fetch('/api/alerts')).json();
+    } catch (e) {
+      statusEl.textContent = 'backend unreachable';
+      return;
+    }
+    const nf = TMAlerts.renderFaults(faultsBox, a.faults, openAlert);
+    const nl = TMAlerts.renderLog(logBox, a.log, openAlert);
+    document.getElementById('al-fault-count').textContent = nf ? `(${nf})` : '';
+    document.getElementById('al-log-count').textContent = nl ? `(${nl})` : '';
+    // The badge is the point of the tab: you see a fault appear without being on it.
+    badge.textContent = nf ? String(nf) : '';
+    badge.style.display = nf ? '' : 'none';
+    statusEl.textContent = a.catalog
+      ? `${nf} active · ${nl} logged`
+      : `${nf} active · ${nl} logged · no firmware alert catalog (set TM3_ROOT for descriptions)`;
+  }
+
+  document.getElementById('alerts-clear').addEventListener('click', async () => {
+    await fetch('/api/alerts/clear', { method: 'POST' }).catch(() => {});
+    refresh();
+  });
+
+  // Polls whether or not the tab is open (it's one small JSON a second, and the
+  // badge has to stay honest); pauses only when the window is hidden.
+  function tick() {
+    if (!document.hidden) refresh();
+  }
+  tabInit.alerts = refresh;
+  setInterval(tick, 1000);
+  refresh();
+})();
+
+// Boot into the tab named in the URL hash (/#odin), else Live. Runs last, so
+// every tab has registered its initializer by now.
+{
+  const want = location.hash.slice(1);
+  const known = document.getElementById('tab-' + want) && !HIDDEN_TABS.has(want);
+  selectTab(known ? want : 'live');
+}
 </script>
 </body>
 </html>

--- a/tests/fixtures/mini.dbc
+++ b/tests/fixtures/mini.dbc
@@ -1,0 +1,10 @@
+VERSION ""
+
+NS_ :
+
+BS_:
+
+BU_: TESTER
+
+BO_ 256 TestMsg: 8 TESTER
+ SG_ TestSig : 0|8@1+ (1,0) [0|255] "" TESTER

--- a/tests/test_can_live.py
+++ b/tests/test_can_live.py
@@ -1,0 +1,282 @@
+"""Tests for scripts/can_live.py logic that stands on its own.
+
+Two areas: the ODIN live cross-reference (/api/seen-signals), which filters the
+arrival-timestamp map by a freshness window and expands the surviving CAN ids to
+the signal names they carry; and the flusher's handling of ids the signal DB does
+not carry. Both run with app state injected directly -- no CAN bus, no reader
+thread.
+"""
+import asyncio
+import contextlib
+import json
+import time
+from pathlib import Path
+
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+import can_live
+from can_decoder import CanDatabase
+
+# A tiny DBC fixture (one message, id 0x100) so these tests never need the MCU
+# firmware compact JSON -- can_live decodes from a DBC just as well.
+_MINI_DBC = Path(__file__).parent / "fixtures" / "mini.dbc"
+
+
+def _test_db() -> CanDatabase:
+    return CanDatabase.from_dbc(_MINI_DBC)
+
+
+@contextlib.asynccontextmanager
+async def _client(seen_msg, msg_signals):
+    app = web.Application()
+    app["seen_msg"] = seen_msg
+    app["msg_signals"] = msg_signals
+    app.router.add_get("/api/seen-signals", can_live._api_seen_signals)
+    async with TestClient(TestServer(app)) as client:
+        yield client
+
+
+class TestSeenSignals:
+    def test_fresh_ids_expand_to_signals_stale_dropped(self):
+        async def body():
+            now = time.monotonic()
+            seen = {0x100: now, 0x200: now - 100.0}          # 0x200 is stale
+            sig = {0x100: ("GTW_drivetrainType", "GTW_epasControlType"),
+                   0x200: ("DI_gear",)}
+            async with _client(seen, sig) as client:
+                r = await client.get("/api/seen-signals")
+                assert r.status == 200
+                data = await r.json()
+                assert data["window"] == can_live._SEEN_WINDOW_S
+                assert "GTW_drivetrainType" in data["signals"]
+                assert "GTW_epasControlType" in data["signals"]
+                assert "DI_gear" not in data["signals"]      # stale id filtered out
+                assert data["signals"] == sorted(data["signals"])
+        asyncio.run(body())
+
+    def test_window_override_widens_freshness(self):
+        async def body():
+            now = time.monotonic()
+            async with _client({0x200: now - 100.0}, {0x200: ("DI_gear",)}) as client:
+                r = await client.get("/api/seen-signals?window=1000")
+                data = await r.json()
+                assert data["signals"] == ["DI_gear"]        # now within the window
+                assert data["window"] == 1000.0
+        asyncio.run(body())
+
+    def test_empty_when_nothing_seen(self):
+        async def body():
+            async with _client({}, {}) as client:
+                data = await (await client.get("/api/seen-signals")).json()
+                assert data["signals"] == []
+        asyncio.run(body())
+
+
+# --------------------------------------------------------------------- flusher
+class _OneShotHub:
+    """Stands in for _BusHub: yields one drain() worth of frames, then nothing."""
+
+    def __init__(self, label, frames):
+        self.label = label
+        self.last_sent = {}
+        self._frames = frames
+
+    def drain(self):
+        latest = {aid: (data, 1.0) for aid, data in self._frames}
+        counts = dict.fromkeys((aid for aid, _ in self._frames), 1)
+        self._frames = []
+        return latest, counts
+
+
+class _Chan:
+    def __init__(self):
+        self.node = ""       # "" == every node
+        self.paused = False
+        self.sent = []
+
+    def offer(self, payload):
+        self.sent.append(payload)
+
+
+async def _flush_once(frames, *, show_unknown=True, node=""):
+    """Run one flusher tick over `frames`, returning the decoded frames a client got."""
+    can_live._DB = _test_db()
+    chan = _Chan()
+    chan.node = node
+    app = {
+        "hubs": [_OneShotHub("vcan0", frames)],
+        "flush_interval": 0.01,
+        "dash_sig": {}, "faults": {}, "alert_ids": {}, "seen_msg": {},
+        # alertLog capture off: these tests are about frame forwarding, and the
+        # decoder would need the MCU firmware libs.
+        "alert_log": {}, "alert_decoder": None, "alertlog_ids": frozenset(),
+        "show_unknown": show_unknown,
+        "clients": {chan}, "raw_clients": set(),
+    }
+    task = asyncio.create_task(can_live._flusher(app))
+    await asyncio.sleep(0.08)
+    task.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await task
+    out = []
+    for payload in chan.sent:
+        out.extend(json.loads(payload).get("frames", []))
+    return out
+
+
+def _an_unknown_id() -> int:
+    """An id the shipped DB genuinely does not carry (0x25C is the sim's APP frame)."""
+    db = _test_db()
+    assert 0x25C not in db.messages
+    return 0x25C
+
+
+class TestUnknownIds:
+    """A frame the DB can't name must still reach the viewer. Dropping it is how a
+    node that IS transmitting comes to look dead -- the regression that hid the
+    sim's APP/PTC nodes once they started sending ids the compact JSON lacks."""
+
+    def test_unknown_id_is_forwarded_undecoded(self):
+        async def body():
+            unknown = _an_unknown_id()
+            got = await _flush_once([(unknown, b"\xde\xad\xbe\xef")])
+            frames = {f["msg_id"]: f for f in got}
+            assert unknown in frames, "unknown id was dropped"
+            f = frames[unknown]
+            assert f["node"] == can_live._UNKNOWN_NODE
+            assert f["unknown"] == 1
+            assert f["data"] == [0xDE, 0xAD, 0xBE, 0xEF]
+        asyncio.run(body())
+
+    def test_known_ids_still_decode_normally(self):
+        async def body():
+            db = _test_db()
+            known = next(iter(db.messages))
+            got = await _flush_once([(known, bytes(8))])
+            frames = {f["msg_id"]: f for f in got}
+            assert known in frames
+            assert "unknown" not in frames[known]
+            assert frames[known]["signals"], "known id should carry decoded signals"
+        asyncio.run(body())
+
+    def test_hide_unknown_restores_the_drop(self):
+        async def body():
+            unknown = _an_unknown_id()
+            got = await _flush_once([(unknown, b"\x01")], show_unknown=False)
+            assert unknown not in {f["msg_id"] for f in got}
+        asyncio.run(body())
+
+    def test_unknown_skipped_for_node_filtered_clients(self):
+        """An unknown id has no originNode, so it can't satisfy a node subscription."""
+        async def body():
+            unknown = _an_unknown_id()
+            got = await _flush_once([(unknown, b"\x01")], node="di")
+            assert unknown not in {f["msg_id"] for f in got}
+        asyncio.run(body())
+
+    def test_repeated_unknown_id_is_marked_same(self):
+        """Byte-identical repeats come back as a bare liveness tick, no payload."""
+        async def body():
+            unknown = _an_unknown_id()
+            payload = b"\x01\x02"
+            got = await _flush_once([(unknown, payload), (unknown, payload)])
+            assert [f["msg_id"] for f in got].count(unknown) >= 1
+        asyncio.run(body())
+
+
+# --------------------------------------------------------------------- filter
+class _Msg:
+    """Minimal stand-in for can.Message: only what _TxFilter.drop looks at."""
+
+    def __init__(self, arbitration_id, is_rx=True):
+        self.arbitration_id = arbitration_id
+        self.is_rx = is_rx
+
+
+def _filter(**kw):
+    kw.setdefault("tx_ids", set())
+    kw.setdefault("ignore_ids", set())
+    kw.setdefault("hide_host_tx", False)
+    kw.setdefault("tx_hidden", False)
+    return can_live._TxFilter(**kw)
+
+
+class TestTxFilter:
+    """python-can sets is_rx=False from MSG_DONTROUTE, which SocketCAN raises for
+    anything sent by ANY local process -- not just this socket (that is
+    MSG_CONFIRM). Dropping on it therefore hides everything vehicle_sim
+    broadcasts, which is what made the sim's nodes look dead in the viewer."""
+
+    def test_locally_originated_frames_are_kept_by_default(self):
+        f = _filter()
+        assert not f.drop(_Msg(0x118, is_rx=False)), (
+            "a frame from another local process (vehicle_sim) must not be dropped"
+        )
+        assert not f.drop(_Msg(0x118, is_rx=True))
+
+    def test_hide_host_tx_drops_every_local_frame_when_asked(self):
+        f = _filter(hide_host_tx=True)
+        assert f.drop(_Msg(0x118, is_rx=False))
+        assert not f.drop(_Msg(0x118, is_rx=True))
+
+    def test_tx_ids_hide_and_unhide_by_id(self):
+        f = _filter(tx_ids={0x132, 0x212}, tx_hidden=True)
+        assert f.drop(_Msg(0x132))
+        assert not f.drop(_Msg(0x118))
+        f.set_tx_hidden(False)
+        assert not f.drop(_Msg(0x132)), "unhiding must bring the ids back"
+        f.set_tx_hidden(True)
+        assert f.drop(_Msg(0x132))
+
+    def test_ignore_ids_are_permanent(self):
+        f = _filter(ignore_ids={0x700}, tx_ids={0x700}, tx_hidden=True)
+        f.set_tx_hidden(False)
+        assert f.drop(_Msg(0x700)), "ignore_ids survive the UI toggle"
+
+
+class TestAlertLogCapture:
+    """The alert-log store folds repeats and skips the idle broadcast.
+
+    Uses a stub decoder so the test needs no firmware libs -- what is under test
+    is can_live's bookkeeping (dedupe key, count, first/last, cap), not the
+    alert_log field packing (tests/test_alert_log.py covers that).
+    """
+
+    class _Dec:
+        def decode(self, can_id, data):
+            from alert_log import AlertLogDecode
+            return AlertLogDecode(can_id=can_id, node="DIR", alert_code=data[0],
+                                  alert=f"DIR_a{data[0]:03d}_stub")
+
+    def test_identical_payloads_fold_into_one_entry(self):
+        store, dec = {}, self._Dec()
+        payload = bytes([0x5E, 0x80, 0xA1, 0x33, 0x1C, 0, 0, 0])
+        can_live._record_alertlog(store, dec, 0x5A5, payload, 100.0)
+        can_live._record_alertlog(store, dec, 0x5A5, payload, 101.5)
+        assert len(store) == 1
+        ent = next(iter(store.values()))
+        assert ent["count"] == 2
+        assert (ent["first"], ent["last"]) == (100.0, 101.5)
+        assert ent["key"] == "5A5:5e80a1331c000000"
+
+    def test_different_payloads_are_separate_entries(self):
+        store, dec = {}, self._Dec()
+        can_live._record_alertlog(store, dec, 0x5A5, bytes([0x5E, 0x80, 1, 0, 0, 0, 0, 0]), 1.0)
+        can_live._record_alertlog(store, dec, 0x5A5, bytes([0x5E, 0x80, 2, 0, 0, 0, 0, 0]), 2.0)
+        assert len(store) == 2
+
+    def test_idle_all_zero_frame_is_ignored(self):
+        """Every ECU broadcasts an empty alert log continuously."""
+        store, dec = {}, self._Dec()
+        can_live._record_alertlog(store, dec, 0x5A5, bytes(8), 1.0)
+        assert store == {}
+
+    def test_store_is_capped_evicting_the_stalest(self):
+        store, dec = {}, self._Dec()
+        for i in range(can_live._ALERT_LOG_CAP + 5):
+            can_live._record_alertlog(
+                store, dec, 0x5A5,
+                bytes([0x5E, 0x80, i & 0xFF, i >> 8, 0, 0, 0, 0]), float(i))
+        assert len(store) == can_live._ALERT_LOG_CAP
+        assert min(e["last"] for e in store.values()) > 0.0, "oldest entries evicted"


### PR DESCRIPTION
Reworks the live CAN viewer into a multi-panel dashboard and drops the hard
dependency on a firmware dump.

- **Dashboard:** a driver HUD (gear / reported gear, immobilizer state,
  telltales, faults, LV/pedal/car-config), an alert-log panel, and the raw signal
  grid -- served from `can_live_ui` (new `dash.html` + `alerts.js`, reworked
  `index.html`).
- **Firmware-optional decoding:** `CanDatabase()` no longer requires the firmware
  compact JSON. With none configured it is an empty DB, so `can_live` runs with
  just a `--dbc` file (or shows raw undecoded frames); decoding simply names
  nothing.
- **Alert-log panel** decodes `<NODE>_alertLog` frames via `alert_log`
  (best-effort).
- Tests use a tiny synthetic DBC fixture (`tests/fixtures/mini.dbc`) so they never
  need the MCU firmware; kept out of the `*.dbc` gitignore via an explicit
  exception.

Full suite green; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
