### PR TITLE
Add .gitattributes to normalize line endings to LF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Normalize line endings to LF on commit (prevents Windows/IDE CRLF flips
+# from showing the whole tree as modified).
+* text=auto eol=lf


### PR DESCRIPTION
Adds `.gitattributes` with `* text=auto eol=lf` so commits always normalize to LF regardless of editor/OS. Prevents the whole tree from showing as "modified" after a Windows IDE (or the WSL harness) rewrites line endings.

The repo is already LF — `git add --renormalize .` is a no-op — so this is a one-line infra change with no content churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
